### PR TITLE
Adjust scale for acc and gyro

### DIFF
--- a/rcb4/armh7interface.py
+++ b/rcb4/armh7interface.py
@@ -35,6 +35,7 @@ from rcb4.struct_header import SensorbaseStruct
 from rcb4.struct_header import ServoStruct
 from rcb4.struct_header import SystemStruct
 from rcb4.struct_header import WormmoduleStruct
+from rcb4.units import convert_data
 
 
 armh7_variable_list = [
@@ -637,6 +638,14 @@ class ARMH7Interface(object):
     def read_rpy(self):
         cs = self.memory_cstruct(Madgwick, 0)
         return [cs.roll, cs.pitch, cs.yaw]
+
+    def read_imu_data(self):
+        cs = self.memory_cstruct(Madgwick, 0)
+        acc = convert_data(cs.acc, 8)
+        q_wxyz = np.array([cs.q0, cs.q1, cs.q2, cs.q3], dtype=np.float32)
+        gyro = convert_data(cs.gyro, 2000)
+        gyro = np.deg2rad(gyro)
+        return q_wxyz, acc, gyro
 
     def gyro_norm_vector(self):
         g = self.memory_cstruct(Madgwick, 0).gyro

--- a/rcb4/units.py
+++ b/rcb4/units.py
@@ -1,0 +1,33 @@
+import numpy as np
+
+
+def convert_data(raw_data, range_g):
+    """Convert raw 16-bit signed integer data
+
+    Convert raw 16-bit signed integer accelerometer data
+    to actual values.
+
+    Parameters
+    ----------
+    raw_data : int or np.ndarray
+        Raw data, expected as 16-bit signed integers.
+    range_g : float
+        The measuring range of the accelerometer in +-g, e.g., 8, 16, 32, 64.
+
+    Returns
+    -------
+    float or np.ndarray
+        The actual values in g. Returns a float if the input is
+        a scalar, or np.ndarray if the input is an array.
+
+    Examples
+    --------
+    >>> convert_data(16000, 8)
+    3.91
+
+    >>> convert_data(np.array([16000, -16000]), 8)
+    np.array([3.91, -3.91])
+    """
+    max_value = 32767
+    conversion_factor = (range_g * 2) / (max_value * 2)
+    return np.array(raw_data) * conversion_factor

--- a/ros/kxr_controller/node_scripts/rcb4_ros_bridge.py
+++ b/ros/kxr_controller/node_scripts/rcb4_ros_bridge.py
@@ -330,12 +330,13 @@ class RCB4ROSBridge(object):
         msg = sensor_msgs.msg.Imu()
         msg.header.frame_id = self.imu_frame_id
         msg.header.stamp = rospy.Time.now()
-        q_wxyz = self.arm.read_quaternion()
+        q_wxyz, acc, gyro = self.arm.read_imu_data()
         (msg.orientation.w, msg.orientation.x,
          msg.orientation.y, msg.orientation.z) = q_wxyz
-        _, gyro = self.arm.gyro_norm_vector()
         (msg.angular_velocity.x, msg.angular_velocity.y,
          msg.angular_velocity.z) = gyro
+        (msg.linear_acceleration.x, msg.linear_acceleration.y,
+         msg.linear_acceleration.z) = acc
         return msg
 
     def run(self):


### PR DESCRIPTION
Related to https://github.com/iory/rcb4/pull/14
This PR sets the scales for gyro and acc to meters and degrees per second.

### test code

```
#!/usr/bin/env python
import rospy
from sensor_msgs.msg import Imu
import numpy as np


def callback(msg):
    angular_norm = np.sqrt(msg.angular_velocity.x ** 2
                           + msg.angular_velocity.y ** 2
                           + msg.angular_velocity.z ** 2)

    acc_norm = np.sqrt(msg.linear_acceleration.x ** 2
                       + msg.linear_acceleration.y ** 2
                       + msg.linear_acceleration.z ** 2)

    if acc_norm > 1.4:
        rospy.loginfo("Detect impact {}".format(acc_norm))


def listener():
    rospy.init_node('listener', anonymous=True)
    rospy.Subscriber("imu", Imu, callback, queue_size=10)
    rospy.spin()

if __name__ == '__main__':
    listener()
```


```
[INFO] [1705382302.899259]: Detect impact 1.4350709673397826
[INFO] [1705382304.198912]: Detect impact 2.5297361374467084
[INFO] [1705382305.154315]: Detect impact 2.13326023903858
[INFO] [1705382321.513858]: Detect impact 1.4318167515840723
[INFO] [1705382321.616729]: Detect impact 1.6437944926118708
[INFO] [1705382321.776413]: Detect impact 1.740089856369743
[INFO] [1705382322.314692]: Detect impact 1.5967120085012034
[INFO] [1705382327.652455]: Detect impact 3.636909679445078
[INFO] [1705382329.275340]: Detect impact 2.246232104121857
[INFO] [1705382330.204769]: Detect impact 1.537381589994245
```
