### PR TITLE
Add interface.py

### DIFF
--- a/ros/kxr_controller/CMakeLists.txt
+++ b/ros/kxr_controller/CMakeLists.txt
@@ -88,7 +88,7 @@ target_link_libraries(kxr_controller
   ${Eigen_LIBRARIES}
 )
 
-file(GLOB PYTHON_SCRIPT_FILES node_scripts/* test/*)
+file(GLOB PYTHON_SCRIPT_FILES scripts/* node_scripts/* test/*)
 catkin_install_python(
   PROGRAMS ${PYTHON_SCRIPT_FILES}
   DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION})

--- a/ros/kxr_controller/requirements.in
+++ b/ros/kxr_controller/requirements.in
@@ -1,1 +1,2 @@
+pyglet==1.4.10
 scikit-robot>=0.0.37

--- a/ros/kxr_controller/scripts/interface.py
+++ b/ros/kxr_controller/scripts/interface.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python
+
+from __future__ import print_function
+
+import argparse
+
+import IPython
+from kxr_controller.kxr_interface import KXRROSRobotInterface
+import rospy
+from skrobot.model import RobotModel
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description='Run KXRROSRobotInterface')
+    parser.add_argument('--viewer', type=str,
+                        help='Specify the viewer: trimesh', default=None)
+    parser.add_argument(
+        '--namespace', type=str, help='Specify the ROS namespace', default='')
+    args = parser.parse_args()
+
+    rospy.init_node('kxr_interface', anonymous=True)
+    robot_model = RobotModel()
+    robot_model.load_urdf_from_robot_description(
+        args.namespace + '/robot_description')
+    ri = KXRROSRobotInterface(  # NOQA
+        robot_model, namespace=args.namespace, controller_timeout=60.0)
+
+    if args.viewer is not None:
+        if args.viewer == 'trimesh':
+            from skrobot.viewers import TrimeshSceneViewer
+            viewer = TrimeshSceneViewer(resolution=(640, 480))
+            viewer.add(robot_model)
+            viewer.show()
+        else:
+            raise NotImplementedError(
+                'Not supported viewer {}'.format(args.viewer))
+
+    # Drop into an IPython shell
+    IPython.embed()
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
```
 ~/ros/kxr  rosrun kxr_controller interface.py --viewer trimesh
Python 3.8.10 (default, Nov 22 2023, 10:22:35)
Type 'copyright', 'credits' or 'license' for more information
IPython 8.12.3 -- An enhanced Interactive Python. Type '?' for help.

In [1]: ri.servo_on()

In [2]: ri.angle_vector(robot_model.init_pose(), 1)
Out[2]: array([0., 0., 0., 0., 0., 0., 0., 0., 0.], dtype=float32)

In [3]: robot_model.rarm_joint2_w.joint_angle(0.9)
Out[3]: 0.9

In [4]: ri.angle_vector(robot_model.angle_vector(), 0.1)
Out[4]: array([0. , 0.9, 0. , 0. , 0. , 0. , 0. , 0. , 0. ], dtype=float32)

In [5]: ri.angle_vector(robot_model.init_pose(), 1)
Out[5]: array([0., 0., 0., 0., 0., 0., 0., 0., 0.], dtype=float32)

In [6]: ri.wait_interpolation()
Out[6]: True
```