### PR TITLE
Add server_ip rosparam for multimaster

### DIFF
--- a/ros/kxr_controller/launch/kxr_controller.launch
+++ b/ros/kxr_controller/launch/kxr_controller.launch
@@ -12,13 +12,13 @@
   <arg name="device" default="" doc="Device path"/>
   <arg name="model_server_port" default="8123" />
 
-  <param name="/model_server_port" value="$(arg model_server_port)" />
-  <node name="http_server_node"
-        pkg="kxr_models" type="http_server_node.py" >
-  </node>
-
   <group if="$(eval len(arg('namespace')) > 0)" ns="$(arg namespace)" >
     <param name="control_loop_rate" value="$(arg control_loop_rate)" />
+    <param name="model_server_port" value="$(arg model_server_port)" />
+    <node name="http_server_node"
+          pkg="kxr_models" type="http_server_node.py" >
+    </node>
+
     <node name="rcb4_ros_bridge"
           pkg="kxr_controller" type="rcb4_ros_bridge.py"
           clear_params="true"
@@ -42,6 +42,11 @@
 
   <group unless="$(eval len(arg('namespace')) > 0)">
     <param name="control_loop_rate" value="$(arg control_loop_rate)" />
+    <param name="model_server_port" value="$(arg model_server_port)" />
+    <node name="http_server_node"
+          pkg="kxr_models" type="http_server_node.py" >
+    </node>
+
     <node name="rcb4_ros_bridge"
           pkg="kxr_controller" type="rcb4_ros_bridge.py"
           clear_params="true"

--- a/ros/kxr_controller/scripts/interface.py
+++ b/ros/kxr_controller/scripts/interface.py
@@ -22,7 +22,7 @@ def main():
 
     rospy.init_node('kxr_interface', anonymous=True)
 
-    download_urdf_mesh_files()
+    download_urdf_mesh_files(args.namespace)
 
     robot_model = RobotModel()
     robot_model.load_urdf_from_robot_description(

--- a/ros/kxr_models/node_scripts/http_server_node.py
+++ b/ros/kxr_models/node_scripts/http_server_node.py
@@ -7,6 +7,7 @@ import threading
 
 from filelock import FileLock
 from filelock import Timeout
+from kxr_models.ros import get_namespace
 import rospkg
 import rospy
 
@@ -66,7 +67,7 @@ if __name__ == '__main__':
     kxreus_path = rospack.get_path('kxr_models')
     www_directory = os.path.join(kxreus_path, 'models')
 
-    port = rospy.get_param('/model_server_port', 8123)
+    port = rospy.get_param(get_namespace() + '/model_server_port', 8123)
     server = ThreadedHTTPServer(
         '0.0.0.0', port, CustomHTTPRequestHandler, www_directory)
     server.start()

--- a/ros/kxr_models/node_scripts/http_server_node.py
+++ b/ros/kxr_models/node_scripts/http_server_node.py
@@ -7,6 +7,7 @@ import threading
 
 from filelock import FileLock
 from filelock import Timeout
+from kxr_models.ip import get_local_ip
 from kxr_models.ros import get_namespace
 import rospkg
 import rospy
@@ -67,7 +68,9 @@ if __name__ == '__main__':
     kxreus_path = rospack.get_path('kxr_models')
     www_directory = os.path.join(kxreus_path, 'models')
 
-    port = rospy.get_param(get_namespace() + '/model_server_port', 8123)
+    namespace = get_namespace()
+    rospy.set_param(namespace + '/model_server_ip', get_local_ip())
+    port = rospy.get_param(namespace + '/model_server_port', 8123)
     server = ThreadedHTTPServer(
         '0.0.0.0', port, CustomHTTPRequestHandler, www_directory)
     server.start()

--- a/ros/kxr_models/python/kxr_models/download_urdf.py
+++ b/ros/kxr_models/python/kxr_models/download_urdf.py
@@ -2,27 +2,27 @@ import os.path as osp
 
 import gdown
 from kxr_models.ros import get_namespace
-import rosgraph
 import rospkg
 import rospy
 
 
-def download_urdf_mesh_files():
-    clean_namespace = get_namespace()
-    port = rospy.get_param(clean_namespace + '/model_server_port', 8123)
+def download_urdf_mesh_files(namespace=None):
+    if namespace is None:
+        namespace = get_namespace()
+    port = rospy.get_param(namespace + '/model_server_port', 8123)
+    server_ip = rospy.get_param(namespace + '/model_server_ip',
+                                'localhost')
 
-    urdf_hash = rospy.get_param(clean_namespace + '/urdf_hash', None)
+    urdf_hash = rospy.get_param(namespace + '/urdf_hash', None)
     rate = rospy.Rate(1)
     while not rospy.is_shutdown() and urdf_hash is None:
         rate.sleep()
         rospy.loginfo('Waiting rosparam {} set'.format(
-            clean_namespace + '/urdf_hash'))
-        urdf_hash = rospy.get_param(clean_namespace + '/urdf_hash', None)
+            namespace + '/urdf_hash'))
+        urdf_hash = rospy.get_param(namespace + '/urdf_hash', None)
 
-    master = rosgraph.Master("")
-    host = master.lookupNode("/rosout").split(':')[1][2:]
     server_url = "http://{}:{}/urdf/{}.tar.gz".format(
-        host, port, urdf_hash)
+        server_ip, port, urdf_hash)
 
     rospack = rospkg.RosPack()
     kxr_models_path = rospack.get_path('kxr_models')

--- a/ros/kxr_models/python/kxr_models/ip.py
+++ b/ros/kxr_models/python/kxr_models/ip.py
@@ -1,0 +1,15 @@
+import socket
+
+
+def get_local_ip():
+    try:
+        s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        s.settimeout(2)
+        s.connect(('8.8.8.8', 80))
+        ip = s.getsockname()[0]
+        s.close()
+    except (socket.timeout, OSError):
+        ip = socket.gethostbyname(socket.gethostname())
+    if ip is None:
+        return 'localhost'
+    return ip

--- a/ros/kxreus/euslisp/kxr-interface.l
+++ b/ros/kxreus/euslisp/kxr-interface.l
@@ -4,7 +4,8 @@
 (ros::load-ros-manifest "kxr_controller")
 
 
-(defun load-robot-model (&key (port 8000) (namespace nil))
+(defun load-robot-model (&key (port 8000) (namespace nil)
+                           (server-ip "localhost"))
   (let* ((hash-param-name (if namespace (format nil "~A~A" namespace "/eusmodel_hash") "/eusmodel_hash"))
          (robot-name-param-name (if namespace (format nil "~A~A" namespace "/eus_robot_name") "/eus_robot_name"))
          hash robot-name outpath server-url)
@@ -22,7 +23,7 @@
     (ros::ros-info (format nil "Get rosparam ~A" robot-name-param-name))
 
     (setq outpath (ros::resolve-ros-path (format nil "package://kxreus/models/cache/~A.l" hash)))
-    (setq server-url (format nil "http://~A:~A/~A.l" (ros::get-host) port hash))
+    (setq server-url (format nil "http://~A:~A/euslisp/~A.l" server-ip port hash))
 
     (when (not (probe-file outpath))
       (while (not (= (unix:system (format nil "wget -O ~A ~A" outpath server-url)) 0))
@@ -108,6 +109,7 @@
                    (create-viewer t))
   (unless (boundp '*robot*)
     (setq *robot* (load-robot-model :namespace namespace
+                                    :server-ip (ros::get-param (if namespace (format nil "~A/model_server_ip" namespace) "/model_server_ip") "localhost")
                                     :port (ros::get-param (if namespace (format nil "~A/model_server_port" namespace) "/model_server_port") 8123))))
   (unless (ros::ok) (ros::roseus "kxr_eus_interface"))
   (unless (boundp '*ri*)


### PR DESCRIPTION
When considering a multimaster setup, each robot has its own roscore, and they each have a server IP and server port. This change involves adding a server_ip ROS parameter, allowing client-side PCs to reference various robots' rosmasters.





