### PR TITLE
Add USB reset functionality before opening serial port

### DIFF
--- a/rcb4/armh7interface.py
+++ b/rcb4/armh7interface.py
@@ -38,6 +38,7 @@ from rcb4.struct_header import ServoStruct
 from rcb4.struct_header import SystemStruct
 from rcb4.struct_header import WormmoduleStruct
 from rcb4.units import convert_data
+from rcb4.usb_utils import reset_usb_device
 
 
 armh7_variable_list = [
@@ -154,6 +155,10 @@ class ARMH7Interface(object):
         serial.SerialException
             If there is an error opening the serial port.
         """
+        # Reset the USB device before opening the serial port
+        reset_usb_device(port)
+        # Wait for 2 seconds to ensure the device is properly reset
+        time.sleep(2.0)
         try:
             self.serial = serial.Serial(port, baudrate, timeout=timeout)
             print(f"Opened {port} at {baudrate} baud")

--- a/rcb4/usb_utils.py
+++ b/rcb4/usb_utils.py
@@ -1,0 +1,56 @@
+import serial
+import usb1
+
+
+def get_vendor_id_and_product_id(port):
+    """Retrieve the vendor ID and product ID for the specified serial port.
+
+    Parameters
+    ----------
+    port : str
+        The serial port for which to retrieve the vendor and product IDs.
+
+    Returns
+    -------
+    tuple
+        A tuple containing the vendor ID and product ID.
+
+    Raises
+    ------
+    ValueError
+        If the USB device information cannot be found for the specified port.
+    """
+    ports = serial.tools.list_ports.comports()
+    for p in ports:
+        if p.device == port:
+            return p.vid, p.pid
+    raise ValueError(f'Could not find USB device information for port {port}')
+
+
+def reset_usb_device(port):
+    """Reset the USB device corresponding to the specified serial port.
+
+    Parameters
+    ----------
+    port : str
+        The serial port whose USB device needs to be reset.
+
+    Raises
+    ------
+    ValueError
+        If the USB device cannot be found.
+    """
+    # Get vendor ID and product ID from the port
+    vendor_id, product_id = get_vendor_id_and_product_id(port)
+    # Create a USB context and open the device by vendor ID and product ID
+    context = usb1.USBContext()
+    handle = context.openByVendorIDAndProductID(
+        vendor_id,
+        product_id,
+        skip_on_error=True
+    )
+    if handle is None:
+        raise ValueError('Device not found')
+    # Reset the USB device
+    handle.resetDevice()
+    print(f"USB device {vendor_id:04x}:{product_id:04x} has been reset.")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 colorama
 cstruct
 gdown
+libusb1
 numpy
 pandas
 pyelftools

--- a/ros/kxr_controller/node_scripts/rcb4_ros_bridge.py
+++ b/ros/kxr_controller/node_scripts/rcb4_ros_bridge.py
@@ -413,6 +413,9 @@ class RCB4ROSBridge(object):
         try:
             av = self.interface.angle_vector()
             torque_vector = self.interface.servo_error()
+        except IndexError as e:
+            rospy.logerr('[publish_joint_states] {}'.format(str(e)))
+            return
         except serial.serialutil.SerialException as e:
             rospy.logerr('[publish_joint_states] {}'.format(str(e)))
             return


### PR DESCRIPTION
- Implement `reset_usb_device` function in `usb_utils.py` to reset USB device based on port.
- Modify `ARMH7Interface` class to reset USB device before initializing serial connection.
- Add `libusb1` dependency in `requirements.txt`.