### PR TITLE
Add stretch server and client to change servo stretch value from ROS system

### DIFF
--- a/rcb4/armh7interface.py
+++ b/rcb4/armh7interface.py
@@ -759,7 +759,7 @@ class ARMH7Interface(object):
 
         Returns
         -------
-        List[int]
+        str
             If b'\x12\x06' (which contains ACK) is returned, command succeed.
             If b'\x12\x15' (which contains NCK) is returned, command fail.
         """

--- a/ros/kxr_controller/CMakeLists.txt
+++ b/ros/kxr_controller/CMakeLists.txt
@@ -63,7 +63,12 @@ catkin_python_setup()
 
 add_action_files(
   DIRECTORY action
-  FILES ServoOnOff.action
+  FILES ServoOnOff.action Stretch.action
+)
+
+add_message_files(
+  DIRECTORY msg
+  FILES Stretch.msg
 )
 
 generate_messages(

--- a/ros/kxr_controller/action/Stretch.action
+++ b/ros/kxr_controller/action/Stretch.action
@@ -1,0 +1,4 @@
+string[] joint_names
+int32 stretch
+---
+---

--- a/ros/kxr_controller/msg/Stretch.msg
+++ b/ros/kxr_controller/msg/Stretch.msg
@@ -1,0 +1,2 @@
+string[] joint_names
+int32[] stretch

--- a/ros/kxr_controller/node_scripts/rcb4_ros_bridge.py
+++ b/ros/kxr_controller/node_scripts/rcb4_ros_bridge.py
@@ -213,7 +213,7 @@ class RCB4ROSBridge(object):
 
         self.stretch_server = actionlib.SimpleActionServer(
             clean_namespace
-            + '/kxr_fullbody_controller/stretch_real_interface',
+            + '/kxr_fullbody_controller/stretch_interface',
             StretchAction,
             execute_cb=self.stretch_callback,
             auto_start=False)

--- a/ros/kxr_controller/node_scripts/rcb4_ros_bridge.py
+++ b/ros/kxr_controller/node_scripts/rcb4_ros_bridge.py
@@ -211,21 +211,23 @@ class RCB4ROSBridge(object):
             auto_start=False)
         self.servo_on_off_server.start()
 
-        self.stretch_server = actionlib.SimpleActionServer(
-            clean_namespace
-            + '/kxr_fullbody_controller/stretch_interface',
-            StretchAction,
-            execute_cb=self.stretch_callback,
-            auto_start=False)
-        self.stretch_server.start()
-        self.stretch_publisher = rospy.Publisher(
-            clean_namespace
-            + '/kxr_fullbody_controller/stretch',
-            Stretch,
-            queue_size=1,
-            latch=True)
-        rospy.sleep(0.1)
-        self.publish_stretch()
+        # TODO (someone) support rcb-4 miniboard
+        if not rospy.get_param('~use_rcb4'):
+            self.stretch_server = actionlib.SimpleActionServer(
+                clean_namespace
+                + '/kxr_fullbody_controller/stretch_interface',
+                StretchAction,
+                execute_cb=self.stretch_callback,
+                auto_start=False)
+            self.stretch_server.start()
+            self.stretch_publisher = rospy.Publisher(
+                clean_namespace
+                + '/kxr_fullbody_controller/stretch',
+                Stretch,
+                queue_size=1,
+                latch=True)
+            rospy.sleep(0.1)
+            self.publish_stretch()
 
         self.proc_controller_spawner = subprocess.Popen(
             [f'/opt/ros/{os.environ["ROS_DISTRO"]}/bin/rosrun',

--- a/ros/kxr_controller/node_scripts/rcb4_ros_bridge.py
+++ b/ros/kxr_controller/node_scripts/rcb4_ros_bridge.py
@@ -10,6 +10,9 @@ import actionlib
 import geometry_msgs.msg
 from kxr_controller.msg import ServoOnOffAction
 from kxr_controller.msg import ServoOnOffResult
+from kxr_controller.msg import Stretch
+from kxr_controller.msg import StretchAction
+from kxr_controller.msg import StretchResult
 import numpy as np
 import rospy
 import sensor_msgs.msg
@@ -208,6 +211,22 @@ class RCB4ROSBridge(object):
             auto_start=False)
         self.servo_on_off_server.start()
 
+        self.stretch_server = actionlib.SimpleActionServer(
+            clean_namespace
+            + '/kxr_fullbody_controller/stretch_real_interface',
+            StretchAction,
+            execute_cb=self.stretch_callback,
+            auto_start=False)
+        self.stretch_server.start()
+        self.stretch_publisher = rospy.Publisher(
+            clean_namespace
+            + '/kxr_fullbody_controller/stretch',
+            Stretch,
+            queue_size=1,
+            latch=True)
+        rospy.sleep(0.1)
+        self.publish_stretch()
+
         self.proc_controller_spawner = subprocess.Popen(
             [f'/opt/ros/{os.environ["ROS_DISTRO"]}/bin/rosrun',
              'controller_manager', 'spawner']
@@ -361,6 +380,43 @@ class RCB4ROSBridge(object):
             self.unsubscribe()
             rospy.signal_shutdown('Disconnected {}.'.format(e))
         return self.servo_on_off_server.set_succeeded(ServoOnOffResult())
+
+    def publish_stretch(self):
+        # Get current stretch of all servo motors and publish them
+        joint_names = []
+        servo_ids = []
+        for joint_name in self.joint_names:
+            if joint_name not in self.joint_name_to_id:
+                continue
+            joint_names.append(joint_name)
+            servo_ids.append(self.joint_name_to_id[joint_name])
+        stretch = self.interface.read_stretch(servo_ids=servo_ids)
+        stretch_msg = Stretch(
+            joint_names=joint_names,
+            stretch=stretch
+        )
+        self.stretch_publisher.publish(stretch_msg)
+
+    def stretch_callback(self, goal):
+        if len(goal.joint_names) == 0:
+            goal.joint_names = self.joint_names
+        joint_names = []
+        servo_ids = []
+        for joint_name in goal.joint_names:
+            if joint_name not in self.joint_name_to_id:
+                continue
+            joint_names.append(joint_name)
+            servo_ids.append(self.joint_name_to_id[joint_name])
+        # Send new stretch
+        stretch = goal.stretch
+        self.interface.send_stretch(
+            value=stretch, servo_ids=servo_ids)
+        # Return result
+        self.publish_stretch()
+        rospy.loginfo(
+            "Update {} stretch to {}".format(
+                joint_names, stretch))
+        return self.stretch_server.set_succeeded(StretchResult())
 
     def publish_imu_message(self):
         msg = sensor_msgs.msg.Imu()

--- a/ros/kxr_controller/node_scripts/rcb4_ros_bridge.py
+++ b/ros/kxr_controller/node_scripts/rcb4_ros_bridge.py
@@ -211,7 +211,7 @@ class RCB4ROSBridge(object):
             auto_start=False)
         self.servo_on_off_server.start()
 
-        # TODO (someone) support rcb-4 miniboard
+        # TODO(someone) support rcb-4 miniboard
         if not rospy.get_param('~use_rcb4'):
             self.stretch_server = actionlib.SimpleActionServer(
                 clean_namespace

--- a/ros/kxr_controller/node_scripts/rcb4_ros_bridge.py
+++ b/ros/kxr_controller/node_scripts/rcb4_ros_bridge.py
@@ -392,7 +392,10 @@ class RCB4ROSBridge(object):
                 continue
             joint_names.append(joint_name)
             servo_ids.append(self.joint_name_to_id[joint_name])
-        stretch = self.interface.read_stretch(servo_ids=servo_ids)
+        try:
+            stretch = self.interface.read_stretch(servo_ids=servo_ids)
+        except serial.serialutil.SerialException as e:
+            rospy.logerr('[read_stretch] {}'.format(str(e)))
         stretch_msg = Stretch(
             joint_names=joint_names,
             stretch=stretch
@@ -411,8 +414,11 @@ class RCB4ROSBridge(object):
             servo_ids.append(self.joint_name_to_id[joint_name])
         # Send new stretch
         stretch = goal.stretch
-        self.interface.send_stretch(
-            value=stretch, servo_ids=servo_ids)
+        try:
+            self.interface.send_stretch(
+                value=stretch, servo_ids=servo_ids)
+        except serial.serialutil.SerialException as e:
+            rospy.logerr('[send_stretch] {}'.format(str(e)))
         # Return result
         self.publish_stretch()
         rospy.loginfo(

--- a/ros/kxr_controller/python/kxr_controller/kxr_interface.py
+++ b/ros/kxr_controller/python/kxr_controller/kxr_interface.py
@@ -29,7 +29,7 @@ class KXRROSRobotInterface(ROSRobotInterfaceBase):
             ServoOnOffAction)
         self.servo_on_off_client.wait_for_server()
         self.stretch_client = actionlib.SimpleActionClient(
-            namespace + '/kxr_fullbody_controller/stretch_real_interface',
+            namespace + '/kxr_fullbody_controller/stretch_interface',
             StretchAction)
         self.stretch_client.wait_for_server()
         self.stretch_topic_name = namespace \

--- a/ros/kxr_controller/python/kxr_controller/kxr_interface.py
+++ b/ros/kxr_controller/python/kxr_controller/kxr_interface.py
@@ -31,7 +31,11 @@ class KXRROSRobotInterface(ROSRobotInterfaceBase):
         self.stretch_client = actionlib.SimpleActionClient(
             namespace + '/kxr_fullbody_controller/stretch_interface',
             StretchAction)
-        self.stretch_client.wait_for_server()
+        timeout = rospy.Duration(10.0)
+        self.enabled_stretch = True
+        if not self.stretch_client.wait_for_server(timeout):
+            rospy.logerr("Stretch action server not available.")
+            self.enabled_stretch = False
         self.stretch_topic_name = namespace \
             + '/kxr_fullbody_controller/stretch'
 
@@ -63,6 +67,9 @@ class KXRROSRobotInterface(ROSRobotInterfaceBase):
         client.send_goal(goal)
 
     def send_stretch(self, value=127, joint_names=None):
+        if not self.enabled_stretch:
+            rospy.logerr('Stretch action server not available.')
+            return
         if joint_names is None:
             joint_names = self.joint_names
         goal = StretchGoal()
@@ -75,6 +82,9 @@ class KXRROSRobotInterface(ROSRobotInterfaceBase):
         client.send_goal(goal)
 
     def read_stretch(self):
+        if not self.enabled_stretch:
+            rospy.logerr('Stretch action server not available.')
+            return
         return rospy.wait_for_message(
             self.stretch_topic_name, Stretch)
 

--- a/ros/kxreus/euslisp/kxr-interface.l
+++ b/ros/kxreus/euslisp/kxr-interface.l
@@ -61,8 +61,8 @@
                                        kxr_controller::ServoOnOffAction
                                        :groupname groupname))
    (setq stretch-client (instance ros::simple-action-client :init
-                                  (if namespace (format nil "/~A/~A/stretch_real_interface" namespace controller-name)
-                                    (format nil "/~A/stretch_real_interface" controller-name))
+                                  (if namespace (format nil "/~A/~A/stretch_interface" namespace controller-name)
+                                    (format nil "/~A/stretch_interface" controller-name))
                                   kxr_controller::StretchAction
                                   :groupname groupname))
    (dolist (action (list servo-on-off-client stretch-client))

--- a/ros/kxreus/euslisp/kxr-interface.l
+++ b/ros/kxreus/euslisp/kxr-interface.l
@@ -60,7 +60,12 @@
                                            (format nil "/~A/servo_on_off" controller-name))
                                        kxr_controller::ServoOnOffAction
                                        :groupname groupname))
-   (dolist (action (list servo-on-off-client))
+   (setq stretch-client (instance ros::simple-action-client :init
+                                  (if namespace (format nil "/~A/~A/stretch_real_interface" namespace controller-name)
+                                    (format nil "/~A/stretch_real_interface" controller-name))
+                                  kxr_controller::StretchAction
+                                  :groupname groupname))
+   (dolist (action (list servo-on-off-client stretch-client))
      (unless (and joint-action-enable (send action :wait-for-server 3))
        (setq joint-action-enable nil)
        (ros::ros-warn "~A is not respond, kxr-interface is disabled" action)
@@ -104,7 +109,22 @@
      (setq goal (instance kxr_controller::ServoOnOffGoal :init))
      (send goal :joint_names names)
      (send goal :servo_on_states (make-array (length names) :initial-element nil))
-     (send servo-on-off-client :send-goal goal))))
+     (send servo-on-off-client :send-goal goal)))
+  (:send-stretch
+   (&key (value 127) (names nil))
+   (when (null names)
+     (setq names joint-names))
+   (let* (goal result)
+     (setq goal (instance kxr_controller::StretchGoal :init))
+     (send goal :joint_names names)
+     (send goal :stretch value)
+     (send stretch-client :send-goal goal)))
+  (:read-stretch
+   ()
+   (one-shot-subscribe
+    (if namespace (format nil "/~A/~A/stretch" namespace controller-name)
+      (format nil "/~A/stretch" controller-name))
+    kxr_controller::Stretch)))
 
 
 (defun kxr-init (&key


### PR DESCRIPTION
Python client

```
python3 interface.py 
Python 3.8.10 (default, Nov 22 2023, 10:22:35) 
Type 'copyright', 'credits' or 'license' for more information
IPython 8.11.0 -- An enhanced Interactive Python. Type '?' for help.

In [1]: ri.read_stretch()
Out[1]: 
joint_names: 
  - joint1
  - joint2
  - joint3
  - joint4
  - joint5
  - joint6
  - joint7
  - gripper_joint1
stretch: [10, 10, 10, 10, 10, 10, 10, 10]

In [2]: ri.send_stretch(30)

In [3]: ri.read_stretch()
Out[3]: 
joint_names: 
  - joint1
  - joint2
  - joint3
  - joint4
  - joint5
  - joint6
  - joint7
  - gripper_joint1
stretch: [30, 30, 30, 30, 30, 30, 30, 30]

```

Euslisp client
```
roseus kxr-interface.l

1.irteusgl$ kxr-init

13.irteusgl$ (let ((a (send *ri* :read-stretch))) (print (send a :joint_names)) (print (send a :stretch)))
("joint1" "joint2" "joint3" "joint4" "joint5" "joint6" "joint7" "gripper_joint1")
#i(100 100 100 100 100 100 100 100)

14.irteusgl$ send *ri* :send-stretch :value 1

15.irteusgl$ (let ((a (send *ri* :read-stretch))) (print (send a :joint_names)) (print (send a :stretch)))
("joint1" "joint2" "joint3" "joint4" "joint5" "joint6" "joint7" "gripper_joint1")
#i(1 1 1 1 1 1 1 1)
```