### PR TITLE
Add SerialException in servo_on_off_callback()

### DIFF
--- a/ros/kxr_controller/node_scripts/rcb4_ros_bridge.py
+++ b/ros/kxr_controller/node_scripts/rcb4_ros_bridge.py
@@ -381,6 +381,8 @@ class RCB4ROSBridge(object):
         except RuntimeError as e:
             self.unsubscribe()
             rospy.signal_shutdown('Disconnected {}.'.format(e))
+        except serial.serialutil.SerialException as e:
+            rospy.logerr('[servo_on_off] {}'.format(str(e)))
         return self.servo_on_off_server.set_succeeded(ServoOnOffResult())
 
     def publish_stretch(self):


### PR DESCRIPTION
This PR catches the following exception.

```
Jun 25 17:04:20 humid-illusion user.service[3529]: '[ERROR] [1719302615.575514] [/rcb4_ros_bridge:rosout]: Exception in your execute callback: Timeout: No data received.
Jun 25 17:04:20 humid-illusion user.service[3529]: Traceback (most recent call last):
Jun 25 17:04:20 humid-illusion user.service[3529]:   File "/opt/ros/noetic/lib/python3/dist-packages/actionlib/simple_action_server.py", line 289, in executeLoop
Jun 25 17:04:20 humid-illusion user.service[3529]:     self.execute_callback(goal)
Jun 25 17:04:20 humid-illusion user.service[3529]:   File "/home/rock/ros/kxr/src/rcb4/ros/kxr_controller/node_scripts/rcb4_ros_bridge.py", line 379, in servo_on_off_callback
Jun 25 17:04:20 humid-illusion user.service[3529]:     self.interface.servo_angle_vector(
Jun 25 17:04:20 humid-illusion user.service[3529]:   File "/home/rock/ros/kxr/src/rcb4/rcb4/armh7interface.py", line 703, in servo_angle_vector
Jun 25 17:04:20 humid-illusion user.service[3529]:     return self.serial_write(byte_list)
Jun 25 17:04:20 humid-illusion user.service[3529]:   File "/home/rock/ros/kxr/src/rcb4/rcb4/armh7interface.py", line 243, in serial_write
Jun 25 17:04:20 humid-illusion user.service[3529]:     ret = self.serial_read()
Jun 25 17:04:20 humid-illusion user.service[3529]:   File "/home/rock/ros/kxr/src/rcb4/rcb4/armh7interface.py", line 258, in serial_read
Jun 25 17:04:20 humid-illusion user.service[3529]:     raise serial.SerialException("Timeout: No data received.")
Jun 25 17:04:20 humid-illusion user.service[3529]: serial.serialutil.SerialException: Timeout: No data received.
```