### PR TITLE
Add PressureControl ROS server and client

### DIFF
--- a/rcb4/armh7interface.py
+++ b/rcb4/armh7interface.py
@@ -30,6 +30,7 @@ from rcb4.rcb4interface import RCB4Interface
 from rcb4.rcb4interface import ServoParams
 from rcb4.struct_header import c_vector
 from rcb4.struct_header import DataAddress
+from rcb4.struct_header import GPIOStruct
 from rcb4.struct_header import Madgwick
 from rcb4.struct_header import max_sensor_num
 from rcb4.struct_header import sensor_sidx
@@ -70,6 +71,10 @@ armh7_variable_list = [
     'Worm_vector',
     'SysB',
     'data_address',
+    'pump_switch',
+    'valve_switch',
+    'gpio_cmd',
+    'GPIO_vector',
 ]
 
 
@@ -617,6 +622,16 @@ class ARMH7Interface(object):
         self.joint_to_actuator_matrix
         return servo_indices
 
+    def search_air_board_ids(self):
+        # air_boards and air_board_ids are in the same order
+        air_boards = self.all_air_boards()
+        air_board_ids = []
+        for air_board in air_boards:
+            for idx in self.id_vector:
+                if air_board.id == idx // 2:
+                    air_board_ids.append(idx)
+        return np.array(air_board_ids)
+
     def valid_servo_ids(self, servo_ids):
         return np.isfinite(self._servo_id_to_sequentialized_servo_id[
             np.array(servo_ids)])
@@ -1108,11 +1123,116 @@ class ARMH7Interface(object):
         return self.memory_cstruct(
             SensorbaseStruct, idx - sensor_sidx)
 
+    def read_gpio_cstruct(self, idx):
+        return self.memory_cstruct(
+            GPIOStruct, idx - sensor_sidx)
+
     def all_jointbase_sensors(self):
         if self.id_vector is None:
             self.read_jointbase_sensor_ids()
         return [self.read_jb_cstruct(idx)
                 for idx in self.id_vector]
+
+    def all_air_boards(self):
+        jointbase_sensors = self.all_jointbase_sensors()
+        return [j for j in jointbase_sensors
+                if j.board_revision == 3]
+
+    def read_pressure_sensor(self, board_idx):
+        """Returns pressure sensor value of air_relay board.
+
+        Equation for calculating pressure value is following
+        - v_diff[V]:
+            (3.1395 * pressure[kPa] + 10.739) / 1000
+            output of wheatstone bridge in pressure sensor
+            when sensor input voltage is 5V, so need to convert for 4.14V.
+            4.14V is determined by constant current circuit.
+            -> See https://api.puiaudio.com/file/2ee7baab-a644-43d5-
+               96e0-0b83ff2e8e64.pdf, p.3
+        - v_amplified[V]:
+            v_diff[V] * GAIN + V_OFFSET[V]
+        - adc_raw:
+            v_amplified[V] / 3.3[V] * 4095 (12bit)
+        """
+        V_OFFSET = 1.65
+        GAIN = 7.4
+
+        all_sensor_data = self.read_jb_cstruct(board_idx)
+        adc_raw = all_sensor_data.adc[3]
+
+        v_amplified = 3.3 * adc_raw / 4095
+        v_diff = (v_amplified - V_OFFSET) / GAIN
+        pressure = (v_diff * 1000 * 5.0 / 4.14 - 10.739) / 3.1395
+        return pressure
+
+    def start_pump(self):
+        """Drive pump. There is supposed to be one pump for the entire system.
+
+        """
+        self.cfunc_call("pump_switch", True)
+
+    def stop_pump(self):
+        """Stop driving pump. There should be one pump for the entire system.
+
+        """
+        self.cfunc_call("pump_switch", False)
+
+    def open_air_connect_valve(self):
+        """Open valve to release air to atmosphere
+
+        """
+        self.cfunc_call("valve_switch", True)
+
+    def close_air_connect_valve(self):
+        """Close valve to shut off air from atmosphere
+
+        """
+        self.cfunc_call("valve_switch", False)
+
+    def gpio_mode(self, board_idx):
+        """Return current GPIO mode of air relay board
+
+        0b: 1 0 0 1 GPIO3 GPIO2 GPIO1 GPIO0
+        """
+        all_gpio_data = self.read_gpio_cstruct(board_idx)
+        gpio_mode = all_gpio_data.mode
+        return gpio_mode
+
+    def open_work_valve(self, board_idx):
+        """Open work valve
+
+        Set GPIO0 to 1
+        """
+        gpio_mode = self.gpio_mode(board_idx)
+        command = gpio_mode | 0b00000001
+        self.cfunc_call('gpio_cmd', board_idx, command)
+
+    def close_work_valve(self, board_idx):
+        """Close work valve
+
+        Set GPIO0 to 0
+        """
+        gpio_mode = self.gpio_mode(board_idx)
+        command = gpio_mode & 0b11111110
+        self.cfunc_call('gpio_cmd', board_idx, command)
+
+    def open_relay_valve(self, board_idx):
+        """Open valve to relay air to next work
+
+        Set GPIO1 to 1
+        """
+        gpio_mode = self.gpio_mode(board_idx)
+        command = gpio_mode | 0b00000010
+        self.cfunc_call('gpio_cmd', board_idx, command)
+
+    def close_relay_valve(self, board_idx):
+        """Close valve to relay air to next work
+
+        Set GPIO1 to 0
+        """
+        gpio_mode = self.gpio_mode(board_idx)
+        command = gpio_mode & 0b11111101
+        self.cfunc_call('gpio_cmd', board_idx, command)
 
     @property
     def servo_id_to_worm_id(self):

--- a/rcb4/data/__init__.py
+++ b/rcb4/data/__init__.py
@@ -17,7 +17,13 @@ ELFINFO = namedtuple('ELFINFO', ['url', 'md5sum'])
 elf_infos = {
     'v0.6.2': ELFINFO(
         'https://github.com/iory/rcb4/releases/download/v0.6.2.elf/v0.6.2.elf',  # NOQA
-        '9205b34ce4d81b87c4f11e6139f96b17')
+        '9205b34ce4d81b87c4f11e6139f96b17'),
+    'v0.6.3': ELFINFO(
+        'https://github.com/iory/rcb4/releases/download/v0.6.3.elf/v0.6.3.elf',  # NOQA
+        '93be022a09d117e5c4338e24a8131901'),
+    'v0.6.4': ELFINFO(
+        'https://github.com/iory/rcb4/releases/download/v0.6.4.elf/v0.6.4.elf',  # NOQA
+        'e1c386f350f780536a51f3bb24cc0cd1'),
 }
 
 

--- a/rcb4/struct_header.py
+++ b/rcb4/struct_header.py
@@ -118,6 +118,19 @@ struct SensorbaseStruct
 """)
 SensorbaseStruct.__name__ = 'Sensor_vector'
 
+
+GPIOStruct = cstruct.parse("""
+struct GPIOStruct
+{
+    uint8_t port;
+    uint8_t id;
+    uint8_t mode;
+    uint8_t gpio_updated;
+};
+""")
+GPIOStruct.__name__ = 'GPIO_vector'
+
+
 ImuData = cstruct.parse("""
 struct ImuData_t
 {

--- a/ros/kxr_controller/CMakeLists.txt
+++ b/ros/kxr_controller/CMakeLists.txt
@@ -63,12 +63,12 @@ catkin_python_setup()
 
 add_action_files(
   DIRECTORY action
-  FILES ServoOnOff.action Stretch.action
+  FILES ServoOnOff.action Stretch.action PressureControl.action
 )
 
 add_message_files(
   DIRECTORY msg
-  FILES Stretch.msg ServoOnOff.msg
+  FILES Stretch.msg ServoOnOff.msg PressureControl.msg
 )
 
 generate_messages(

--- a/ros/kxr_controller/action/PressureControl.action
+++ b/ros/kxr_controller/action/PressureControl.action
@@ -1,0 +1,5 @@
+uint16 board_idx  # Do not use board id? (Currently, bus-connected air board is not supported)
+float32 threshold  # Threshold [kPa] to start pump (Currently, pressurization is not supported)
+bool release  # Set true to release air by opening valve.
+---
+---

--- a/ros/kxr_controller/launch/kxr_controller.launch
+++ b/ros/kxr_controller/launch/kxr_controller.launch
@@ -6,6 +6,7 @@
   <arg name="publish_imu" default="true" />
   <arg name="publish_sensor" default="false" />
   <arg name="publish_battery_voltage" default="false" />
+  <arg name="control_pressure" default="false" />
   <arg name="imu_frame_id" default="/bodyset94472077639384" />
   <arg name="control_loop_rate" default="20" />
   <arg name="use_rcb4" default="false" doc="Flag to use RCB4 mini board"/>
@@ -37,6 +38,7 @@
         publish_imu: $(arg publish_imu)
         publish_sensor: $(arg publish_sensor)
         publish_battery_voltage: $(arg publish_battery_voltage)
+        control_pressure: $(arg control_pressure)
         imu_frame_id: $(arg namespace)/$(arg imu_frame_id)
         use_rcb4: $(arg use_rcb4)
       </rosparam>
@@ -70,6 +72,7 @@
         publish_imu: $(arg publish_imu)
         publish_sensor: $(arg publish_sensor)
         publish_battery_voltage: $(arg publish_battery_voltage)
+        control_pressure: $(arg control_pressure)
         imu_frame_id: $(arg imu_frame_id)
         use_rcb4: $(arg use_rcb4)
       </rosparam>

--- a/ros/kxr_controller/msg/PressureControl.msg
+++ b/ros/kxr_controller/msg/PressureControl.msg
@@ -1,0 +1,3 @@
+uint16 board_idx  # Do not use board id? (Currently, bus-connected air board is not supported)
+float32 threshold  # Threshold [kPa] to start pump (Currently, pressurization is not supported)
+bool release  # Set true to release air by opening valve.

--- a/ros/kxr_controller/python/kxr_controller/kxr_interface.py
+++ b/ros/kxr_controller/python/kxr_controller/kxr_interface.py
@@ -1,6 +1,8 @@
 import actionlib
 import actionlib_msgs.msg
 import control_msgs.msg
+from kxr_controller.msg import PressureControlAction
+from kxr_controller.msg import PressureControlGoal
 from kxr_controller.msg import ServoOnOffAction
 from kxr_controller.msg import ServoOnOffGoal
 from kxr_controller.msg import Stretch
@@ -8,6 +10,7 @@ from kxr_controller.msg import StretchAction
 from kxr_controller.msg import StretchGoal
 import rospy
 from skrobot.interfaces.ros.base import ROSRobotInterfaceBase
+import std_msgs.msg
 
 
 class KXRROSRobotInterface(ROSRobotInterfaceBase):
@@ -24,10 +27,12 @@ class KXRROSRobotInterface(ROSRobotInterfaceBase):
             rospy.logwarn('Waiting {} set'.format(joint_param))
             rate.sleep()
         super(KXRROSRobotInterface, self).__init__(*args, **kwargs)
+        # Servo on off client
         self.servo_on_off_client = actionlib.SimpleActionClient(
             namespace + '/kxr_fullbody_controller/servo_on_off',
             ServoOnOffAction)
         self.servo_on_off_client.wait_for_server()
+        # Stretch client
         self.stretch_client = actionlib.SimpleActionClient(
             namespace + '/kxr_fullbody_controller/stretch_interface',
             StretchAction)
@@ -38,6 +43,20 @@ class KXRROSRobotInterface(ROSRobotInterfaceBase):
             self.enabled_stretch = False
         self.stretch_topic_name = namespace \
             + '/kxr_fullbody_controller/stretch'
+        # Pressure control client
+        pressure_param = namespace + '/rcb4_ros_bridge/control_pressure'
+        self.control_pressure = rospy.get_param(pressure_param, False)
+        if self.control_pressure is True:
+            self.pressure_control_client = actionlib.SimpleActionClient(
+                namespace
+                + '/kxr_fullbody_controller/pressure_control_interface',
+                PressureControlAction)
+            self.enabled_pressure_control = True
+            if not self.pressure_control_client.wait_for_server(timeout):
+                rospy.logerr("PressureControl action server not available.")
+                self.enabled_pressure_control = False
+            self.pressure_topic_name_base = namespace \
+                + '/kxr_fullbody_controller/pressure/'
 
     def servo_on(self, joint_names=None):
         if joint_names is None:
@@ -92,6 +111,25 @@ class KXRROSRobotInterface(ROSRobotInterfaceBase):
             return
         return rospy.wait_for_message(
             self.stretch_topic_name, Stretch)
+
+    def send_pressure_control(self, board_idx, threshold, release):
+        goal = PressureControlGoal(
+            board_idx=board_idx,
+            threshold=threshold,
+            release=release)
+        client = self.pressure_control_client
+        if client.get_state() == actionlib_msgs.msg.GoalStatus.ACTIVE:
+            client.cancel_goal()
+            client.wait_for_result(timeout=rospy.Duration(10))
+        client.send_goal(goal)
+
+    def read_pressure(self, board_idx):
+        if not self.enabled_pressure_control:
+            rospy.logerr('Pressure control action server not available.')
+            return
+        return rospy.wait_for_message(
+            self.pressure_topic_name_base+f'{board_idx}',
+            std_msgs.msg.Float32)
 
     @property
     def fullbody_controller(self):

--- a/ros/kxreus/euslisp/kxr-interface.l
+++ b/ros/kxreus/euslisp/kxr-interface.l
@@ -43,7 +43,9 @@
    (let* ((namespace (cadr (memq :namespace args)))
           (c-name (cadr (memq :controller-name args)))
           (joint-param (if namespace (format nil "~A/~A/joints" namespace c-name)
-                           (format nil "/~A/joints" c-name))))
+                         (format nil "/~A/joints" c-name)))
+          (pressure-param (if namespace (format nil "~A/rcb4_ros_bridge/control_pressure" namespace)
+                            (format nil "/rcb4_ros_bridge/control_pressure"))))
      (setq controller-name (cadr (memq :controller-name args)))
      (setq joint-names (ros::get-param joint-param nil))
      (while (and (ros::ok) (null joint-names))
@@ -65,7 +67,15 @@
                                     (format nil "/~A/stretch_interface" controller-name))
                                   kxr_controller::StretchAction
                                   :groupname groupname))
-   (dolist (action (list servo-on-off-client stretch-client))
+   (setq control-pressure (ros::get-param pressure-param nil))
+   (when control-pressure
+     (setq pressure-control-client (instance ros::simple-action-client :init
+                                             (if namespace (format nil "/~A/~A/pressure_control_interface" namespace controller-name)
+                                               (format nil "/~A/pressure_control_interface" controller-name))
+                                             kxr_controller::PressureControlAction
+                                             :groupname groupname)))
+   (dolist (action (if control-pressure (list servo-on-off-client stretch-client pressure-control-client)
+                     (list servo-on-off-client stretch-client)))
      (unless (and joint-action-enable (send action :wait-for-server 3))
        (setq joint-action-enable nil)
        (ros::ros-warn "~A is not respond, kxr-interface is disabled" action)
@@ -129,7 +139,21 @@
    (one-shot-subscribe
     (if namespace (format nil "/~A/~A/stretch" namespace controller-name)
       (format nil "/~A/stretch" controller-name))
-    kxr_controller::Stretch)))
+    kxr_controller::Stretch))
+  (:send-pressure-control
+   (&key board-idx threshold release)
+   (let* (goal result)
+     (setq goal (instance kxr_controller::PressureControlGoal :init))
+     (send goal :board_idx board-idx)
+     (send goal :threshold threshold)
+     (send goal :release release)
+     (send pressure-control-client :send-goal goal)))
+  (:read-pressure
+   (&key board-idx)
+   (one-shot-subscribe
+    (if namespace (format nil "/~A/~A/pressure/~A" namespace controller-name board-idx)
+      (format nil "/~A/pressure/~A" controller-name board-idx))
+    std_msgs::Float32)))
 
 
 (defun kxr-init (&key

--- a/ros/kxreus/euslisp/kxr-interface.l
+++ b/ros/kxreus/euslisp/kxr-interface.l
@@ -35,7 +35,7 @@
 
 (defclass kxr-interface
   :super robot-interface
-  :slots (joint-names servo-on-off-client controller-name))
+  :slots (joint-names servo-on-off-client controller-name control-pressure))
 
 
 (defmethod kxr-interface
@@ -46,6 +46,7 @@
                          (format nil "/~A/joints" c-name)))
           (pressure-param (if namespace (format nil "~A/rcb4_ros_bridge/control_pressure" namespace)
                             (format nil "/rcb4_ros_bridge/control_pressure"))))
+     (setq control-pressure (ros::get-param pressure-param nil))
      (setq controller-name (cadr (memq :controller-name args)))
      (setq joint-names (ros::get-param joint-param nil))
      (while (and (ros::ok) (null joint-names))
@@ -67,7 +68,6 @@
                                     (format nil "/~A/stretch_interface" controller-name))
                                   kxr_controller::StretchAction
                                   :groupname groupname))
-   (setq control-pressure (ros::get-param pressure-param nil))
    (when control-pressure
      (setq pressure-control-client (instance ros::simple-action-client :init
                                              (if namespace (format nil "/~A/~A/pressure_control_interface" namespace controller-name)


### PR DESCRIPTION
# Server usage

Set `control_pressure` as true.

```
<launch>

  <include file="$(find kxr_controller)/launch/kxr_controller.launch">
    <arg name="urdf_path" value="$(find yamaguchi_7axis_arm_no_worm_with_vacuum_base_ver3)/urdf/yamaguchi_7axis_arm_no_worm_with_vacuum_base_ver3_color.urdf" />
    <arg name="servo_config_path" value="$(find yamaguchi_7axis_arm_no_worm_with_vacuum_base_ver3)/config/servo_config.yaml" />
    <arg name="publish_sensor" value="false" />
    <arg name="control_pressure" value="true" />
    <arg name="control_loop_rate" value="20" />
  </include>

</launch>
```

# Client usage

## keep pressure under -10[kPa]

Set `threshold` field as -10 and `release` field as false.

Shell
```
$ rostopic pub /kxr_fullbody_controller/pressure_control_interface/goal kxr_controller/PressureControlActionGoal "header:
  seq: 0
  stamp:
    secs: 0
    nsecs: 0
  frame_id: ''
goal_id:
  stamp:
    secs: 0
    nsecs: 0
  id: ''
goal:
  board_idx: 39
  threshold: -10.0
  release: false" 
```

Python
```
roscd kxr_controller/scripts
python3 interface.py
In [1]: ri.send_pressure_control(39, threshold=-10, release=False)
```

Euslisp
```
roscd kxreus/euslisp
roseus kxr-interface.l
(kxr-init)
(send *ri* :send-pressure-control :board-idx 39 :threshold -10 :release nil)
```

## Connect to atmosphere

Set `release` field as true.

Shell
```
$ rostopic pub /kxr_fullbody_controller/pressure_control_interface/goal kxr_controller/PressureControlActionGoal "header:
  seq: 0
  stamp:
    secs: 0
    nsecs: 0
  frame_id: ''
goal_id:
  stamp:
    secs: 0
    nsecs: 0
  id: ''
goal:
  board_idx: 39
  threshold: -10.0
  release: true" 
```

Python
```
roscd kxr_controller/scripts
python3 interface.py
In [1]: ri.send_pressure_control(39, threshold=-10, release=True)
```

Euslisp
```
roscd kxreus/euslisp
roseus kxr-interface.l
(kxr-init)
(send *ri* :send-pressure-control :board-idx 39 :threshold -10 :release t)
```

## Get current pressure

Shell
```
rostopic echo /kxr_fullbody_controller/pressure/39
data: 2.004485607147217
---                      
data: -0.006360102444887161
---                    
data: 0.9152774810791016
---                       
```

Python
```
roscd kxr_controller/scripts
python3 interface.py
In [1]: ri.read_pressure(39)
Out[1]: data: -16.13501739501953
```

Euslisp
```
roscd kxreus/euslisp
roseus kxr-interface.l
(kxr-init)
(send (send *ri* :read-pressure :board-idx 39) :data)
-11.8201
```

# elf files

v0.6.3 https://github.com/nakane11/control_boards/releases/tag/v0.6.3.elf
v0.6.4 https://github.com/708yamaguchi/rcb4/releases/tag/v0.6.4.elf