### PR TITLE
Initialize self.interface every time

### DIFF
--- a/ros/kxr_controller/node_scripts/rcb4_ros_bridge.py
+++ b/ros/kxr_controller/node_scripts/rcb4_ros_bridge.py
@@ -173,6 +173,7 @@ class RCB4ROSBridge(object):
             JointState,
             queue_size=1)
 
+        self.interface = None
         while not rospy.is_shutdown():
             try:
                 if rospy.get_param('~device', None):


### PR DESCRIPTION
This PR fixes the following error.

```
Aug 02 16:00:11 plucky-moonshadow user.service[4061]: Traceback (most recent call last):                                                                                                                                                                              
Aug 02 16:00:11 plucky-moonshadow user.service[4061]:   File "/home/rock/ros/kxr/devel/lib/kxr_controller/rcb4_ros_bridge.py", line 15, in <module>                                                                                                                   
Aug 02 16:00:11 plucky-moonshadow user.service[4061]:     exec(compile(fh.read(), python_script, 'exec'), context)                                                                                                                                                    
Aug 02 16:00:11 plucky-moonshadow user.service[4061]:   File "/home/rock/ros/kxr/src/rcb4/ros/kxr_controller/node_scripts/rcb4_ros_bridge.py", line 648, in <module>                                                                                                  
Aug 02 16:00:11 plucky-moonshadow user.service[4061]:     ros_bridge = RCB4ROSBridge()  # NOQA                                                                                                                                                                        
Aug 02 16:00:11 plucky-moonshadow user.service[4061]:   File "/home/rock/ros/kxr/src/rcb4/ros/kxr_controller/node_scripts/rcb4_ros_bridge.py", line 168, in __init__                                                                                                  
Aug 02 16:00:11 plucky-moonshadow user.service[4061]:     if self.interface is None:                                                                                                                                                                                  
Aug 02 16:00:11 plucky-moonshadow user.service[4061]: AttributeError: 'RCB4ROSBridge' object has no attribute 'interface' 
```