### PR TITLE
Publish servo on/off state

### DIFF
--- a/ros/kxr_controller/CMakeLists.txt
+++ b/ros/kxr_controller/CMakeLists.txt
@@ -68,7 +68,7 @@ add_action_files(
 
 add_message_files(
   DIRECTORY msg
-  FILES Stretch.msg
+  FILES Stretch.msg ServoOnOff.msg
 )
 
 generate_messages(

--- a/ros/kxr_controller/msg/ServoOnOff.msg
+++ b/ros/kxr_controller/msg/ServoOnOff.msg
@@ -1,0 +1,1 @@
+bool[] servo_on_states


### PR DESCRIPTION
Publish `~state` topic so that nodes other than `rcb4_ros_bridge` (e.g. `button_action_manager.py`) can get the ON/OFF status of the servo.