### PR TITLE
Add sleep(0.1) before publishing topic

### DIFF
--- a/ros/kxr_controller/node_scripts/rcb4_ros_bridge.py
+++ b/ros/kxr_controller/node_scripts/rcb4_ros_bridge.py
@@ -267,7 +267,8 @@ class RCB4ROSBridge(object):
                 StretchAction,
                 execute_cb=self.stretch_callback,
                 auto_start=False)
-            # Avoid 'rospy.exceptions.ROSException: publish() to a closed topic'
+            # Avoid 'rospy.exceptions.ROSException:
+            # publish() to a closed topic'
             rospy.sleep(0.1)
             self.stretch_server.start()
             self.stretch_publisher = rospy.Publisher(
@@ -276,7 +277,8 @@ class RCB4ROSBridge(object):
                 Stretch,
                 queue_size=1,
                 latch=True)
-            # Avoid 'rospy.exceptions.ROSException: publish() to a closed topic'
+            # Avoid 'rospy.exceptions.ROSException:
+            # publish() to a closed topic'
             rospy.sleep(0.1)
             self.publish_stretch()
 
@@ -519,7 +521,8 @@ class RCB4ROSBridge(object):
                             + '/kjs/{}/{}/{}'.format(sensor.id, typ, i),
                             geometry_msgs.msg.WrenchStamped,
                             queue_size=1)
-                        # Avoid 'rospy.exceptions.ROSException: publish() to a closed topic'
+                        # Avoid 'rospy.exceptions.ROSException:
+                        # publish() to a closed topic'
                         rospy.sleep(0.1)
                     msg.header.frame_id = 'kjs_{}_{}_frame'.format(
                         sensor.id, i)

--- a/ros/kxr_controller/node_scripts/rcb4_ros_bridge.py
+++ b/ros/kxr_controller/node_scripts/rcb4_ros_bridge.py
@@ -255,6 +255,8 @@ class RCB4ROSBridge(object):
             ServoOnOffAction,
             execute_cb=self.servo_on_off_callback,
             auto_start=False)
+        # Avoid 'rospy.exceptions.ROSException: publish() to a closed topic'
+        rospy.sleep(0.1)
         self.servo_on_off_server.start()
 
         # TODO(someone) support rcb-4 miniboard
@@ -265,6 +267,8 @@ class RCB4ROSBridge(object):
                 StretchAction,
                 execute_cb=self.stretch_callback,
                 auto_start=False)
+            # Avoid 'rospy.exceptions.ROSException: publish() to a closed topic'
+            rospy.sleep(0.1)
             self.stretch_server.start()
             self.stretch_publisher = rospy.Publisher(
                 clean_namespace
@@ -272,6 +276,7 @@ class RCB4ROSBridge(object):
                 Stretch,
                 queue_size=1,
                 latch=True)
+            # Avoid 'rospy.exceptions.ROSException: publish() to a closed topic'
             rospy.sleep(0.1)
             self.publish_stretch()
 
@@ -514,6 +519,8 @@ class RCB4ROSBridge(object):
                             + '/kjs/{}/{}/{}'.format(sensor.id, typ, i),
                             geometry_msgs.msg.WrenchStamped,
                             queue_size=1)
+                        # Avoid 'rospy.exceptions.ROSException: publish() to a closed topic'
+                        rospy.sleep(0.1)
                     msg.header.frame_id = 'kjs_{}_{}_frame'.format(
                         sensor.id, i)
                     self._sensor_publisher_dict[key].publish(msg)


### PR DESCRIPTION
Sometimes `rcb4_ros_bridge.py` fails with the following error.
```
Aug 16 15:07:44 amplifying-lichen user.service[3029]: '[ERROR] [1723788457.335167] [/rcb4_ros_bridge:rosout]: [publish_pressure] Timeout: No data received.'
Aug 16 15:07:44 amplifying-lichen user.service[3029]: Exception in thread Thread-11:
Aug 16 15:07:44 amplifying-lichen user.service[3029]: Traceback (most recent call last):
Aug 16 15:07:44 amplifying-lichen user.service[3029]:   File "/usr/lib/python3.8/threading.py", line 932, in _bootstrap_inner
Aug 16 15:07:44 amplifying-lichen user.service[3029]:     self.run()
Aug 16 15:07:44 amplifying-lichen user.service[3029]:   File "/opt/ros/noetic/lib/python3/dist-packages/rospy/timer.py", line 237, in run
Aug 16 15:07:44 amplifying-lichen user.service[3029]:     self._callback(TimerEvent(last_expected, last_real, current_expected, current_real, last_duration))
Aug 16 15:07:44 amplifying-lichen user.service[3029]:   File "/opt/ros/noetic/lib/python3/dist-packages/actionlib/action_server.py", line 301, in publish_status_async
Aug 16 15:07:44 amplifying-lichen user.service[3029]:     self.publish_status()
Aug 16 15:07:44 amplifying-lichen user.service[3029]:   File "/opt/ros/noetic/lib/python3/dist-packages/actionlib/action_server.py", line 325, in publish_status
Aug 16 15:07:44 amplifying-lichen user.service[3029]:     self.status_pub.publish(status_array)
Aug 16 15:07:44 amplifying-lichen user.service[3029]:   File "/opt/ros/noetic/lib/python3/dist-packages/rospy/topics.py", line 882, in publish
Aug 16 15:07:44 amplifying-lichen user.service[3029]:     self.impl.publish(data)
Aug 16 15:07:44 amplifying-lichen user.service[3029]:   File "/opt/ros/noetic/lib/python3/dist-packages/rospy/topics.py", line 1041, in publish
Aug 16 15:07:44 amplifying-lichen user.service[3029]:     raise ROSException("publish() to a closed topic")
Aug 16 15:07:44 amplifying-lichen user.service[3029]: rospy.exceptions.ROSException: publish() to a closed topic
```
The entire log: https://gist.github.com/708yamaguchi/354a60a54c42dd4425a7b40e6514f2d3

If I put sleep(0.1) between creation and start of action servers, this error does not seem to occur.

I am not sure, but it seems that the error occurs when the `~status` topic is published immediately after the status publisher is generated inside the action server.
