### PR TITLE
Add v0.6.5 elf file

### DIFF
--- a/rcb4/data/__init__.py
+++ b/rcb4/data/__init__.py
@@ -24,6 +24,9 @@ elf_infos = {
     'v0.6.4': ELFINFO(
         'https://github.com/iory/rcb4/releases/download/v0.6.4.elf/v0.6.4.elf',  # NOQA
         'e1c386f350f780536a51f3bb24cc0cd1'),
+    'v0.6.5': ELFINFO(
+        'https://github.com/iory/rcb4/releases/download/v0.6.5.elf/v0.6.5.elf',  # NOQA
+        '2ec2d0cde4c3d5c5a9da2f705d3c6c50'),
 }
 
 


### PR DESCRIPTION
Since pump power board rev.3 switches the pump and solenoid valve in GPIO open-drain mode, the kondoh7 firmware was changed to v0.6.5.
The original firmware is found in https://github.com/nakane11/control_boards/tree/air-relay-rev2.

Before merging, please put the following files in https://github.com/iory/rcb4/releases/download/v0.6.5.elf/v0.6.5.elf.

v0.6.5.elf: https://github.com/nakane11/control_boards/releases/download/v0.6.5/v0.6.5.elf