### PR TITLE
Add dynamic reconfigure server and set default frame count 5

### DIFF
--- a/ros/kxr_controller/CMakeLists.txt
+++ b/ros/kxr_controller/CMakeLists.txt
@@ -34,6 +34,7 @@ if(USE_VIRTUALENV)
     catkin_virtualenv
     actionlib
     actionlib_msgs
+    dynamic_reconfigure
     std_msgs
     roscpp
     cmake_modules
@@ -46,6 +47,7 @@ else()
   find_package(catkin REQUIRED COMPONENTS
     actionlib
     actionlib_msgs
+    dynamic_reconfigure
     std_msgs
     roscpp
     cmake_modules
@@ -69,6 +71,11 @@ add_action_files(
 add_message_files(
   DIRECTORY msg
   FILES Stretch.msg ServoOnOff.msg PressureControl.msg
+)
+
+# generate the dynamic_reconfigure config file
+generate_dynamic_reconfigure_options(
+  cfg/KXRParameteres.cfg
 )
 
 generate_messages(

--- a/ros/kxr_controller/cfg/KXRParameteres.cfg
+++ b/ros/kxr_controller/cfg/KXRParameteres.cfg
@@ -6,7 +6,8 @@ from dynamic_reconfigure.parameter_generator_catkin import ParameterGenerator
 from dynamic_reconfigure.parameter_generator_catkin import int_t
 
 gen = ParameterGenerator()
-gen.add("frame_count", int_t, 0, "Frame Count", 1, 1, 255)
+# The value 5 for frame_count was experimentally confirmed to enable smooth interpolation
+gen.add("frame_count", int_t, 0, "Frame Count", 5, 1, 255)
 gen.add("wheel_frame_count", int_t, 0, "Frame Count for Wheel", 1, 1, 255)
 
 exit(gen.generate(PACKAGE, PACKAGE, "KXRParameteres"))

--- a/ros/kxr_controller/cfg/KXRParameteres.cfg
+++ b/ros/kxr_controller/cfg/KXRParameteres.cfg
@@ -1,0 +1,12 @@
+#!/usr/bin/env python
+
+PACKAGE = 'kxr_controller'
+
+from dynamic_reconfigure.parameter_generator_catkin import ParameterGenerator
+from dynamic_reconfigure.parameter_generator_catkin import int_t
+
+gen = ParameterGenerator()
+gen.add("frame_count", int_t, 0, "Frame Count", 1, 1, 255)
+gen.add("wheel_frame_count", int_t, 0, "Frame Count for Wheel", 1, 1, 255)
+
+exit(gen.generate(PACKAGE, PACKAGE, "KXRParameteres"))

--- a/ros/kxr_controller/node_scripts/rcb4_ros_bridge.py
+++ b/ros/kxr_controller/node_scripts/rcb4_ros_bridge.py
@@ -12,6 +12,8 @@ import xml.etree.ElementTree as ET
 
 import actionlib
 import geometry_msgs.msg
+from dynamic_reconfigure.server import Server
+from kxr_controller.cfg import KXRParameteresConfig as Config
 from kxr_controller.msg import PressureControl
 from kxr_controller.msg import PressureControlAction
 from kxr_controller.msg import PressureControlResult
@@ -208,6 +210,8 @@ class RCB4ROSBridge(object):
             sys.exit(1)
         self._prev_velocity_command = None
 
+        self.srv = Server(Config, self.config_callback)
+
         # set servo ids to rosparam
         rospy.set_param(clean_namespace + '/servo_ids',
                         self.interface.search_servo_ids().tolist())
@@ -369,6 +373,11 @@ class RCB4ROSBridge(object):
         self.command_joint_state_sub.unregister()
         self.velocity_command_joint_state_sub.unregister()
 
+    def config_callback(self, config, level):
+        self.frame_count = config.frame_count
+        self.wheel_frame_count = config.wheel_frame_count
+        return config
+
     def check_servo_states(self):
         self.joint_servo_on = {jn: False for jn in self.joint_names}
         servo_on_states = self.interface.servo_states()
@@ -445,7 +454,8 @@ class RCB4ROSBridge(object):
                 self._prev_velocity_command, av):
             return
         try:
-            self.interface.angle_vector(av, servo_ids, velocity=0)
+            self.interface.angle_vector(
+                av, servo_ids, velocity=self.wheel_frame_count)
             self._prev_velocity_command = av
         except serial.serialutil.SerialException as e:
             rospy.logerr('[velocity_command_joint] {}'.format(str(e)))
@@ -456,7 +466,8 @@ class RCB4ROSBridge(object):
         if len(av) == 0:
             return
         try:
-            self.interface.angle_vector(av, servo_ids, velocity=1)
+            self.interface.angle_vector(
+                av, servo_ids, velocity=self.frame_count)
         except serial.serialutil.SerialException as e:
             rospy.logerr('[command_joint] {}'.format(str(e)))
 

--- a/ros/kxr_controller/package.xml
+++ b/ros/kxr_controller/package.xml
@@ -13,6 +13,7 @@
 
   <build_depend>roscpp</build_depend>
   <build_depend>controller_manager</build_depend>
+  <build_depend>dynamic_reconfigure</build_depend>
   <build_depend>hardware_interface</build_depend>
   <build_depend>angles</build_depend>
   <build_depend>urdf</build_depend>
@@ -30,6 +31,7 @@
   <exec_depend>position_controllers</exec_depend>
   <exec_depend>angles</exec_depend>
   <exec_depend>diff_drive_controller</exec_depend>
+  <exec_depend>dynamic_reconfigure</exec_depend>
   <exec_depend>urdf</exec_depend>
   <exec_depend>cmake_modules</exec_depend>
   <exec_depend>kxr_models</exec_depend>


### PR DESCRIPTION
The velocity parameter for Kondo servos represents the frame count. It was experimentally confirmed that 5 is a good value.
