### PR TITLE
Publish joint names in ServoOnOff msg

### DIFF
--- a/ros/kxr_controller/msg/ServoOnOff.msg
+++ b/ros/kxr_controller/msg/ServoOnOff.msg
@@ -1,1 +1,2 @@
+string[] joint_names
 bool[] servo_on_states

--- a/ros/kxr_controller/node_scripts/rcb4_ros_bridge.py
+++ b/ros/kxr_controller/node_scripts/rcb4_ros_bridge.py
@@ -497,10 +497,8 @@ class RCB4ROSBridge:
             servo_ids.append(self.joint_name_to_id[joint_name])
             if servo_on:
                 servo_vector.append(32767)
-                self.joint_servo_on[joint_name] = True
             else:
                 servo_vector.append(32768)
-                self.joint_servo_on[joint_name] = False
         try:
             self.interface.servo_angle_vector(servo_ids, servo_vector, velocity=1)
         except RuntimeError as e:
@@ -791,8 +789,12 @@ class RCB4ROSBridge:
         self.current_joint_states_pub.publish(msg)
 
     def publish_servo_on_off(self):
-        servo_on_states = list(self.joint_servo_on.values())
-        self.servo_on_off_pub.publish(servo_on_states)
+        self.check_servo_states()
+        servo_on_off_msg = ServoOnOff()
+        servo_on_off_msg.joint_names = list(self.joint_servo_on.keys())
+        servo_on_off_msg.servo_on_states = list(
+            self.joint_servo_on.values())
+        self.servo_on_off_pub.publish(servo_on_off_msg)
 
     def run(self):
         rate = rospy.Rate(


### PR DESCRIPTION
In this pull request, joint names are now published within the ServoOnOff message.

Additionally, instead of assigning values to self.joint_servo_on within servo_on_off_callback(), this has been standardized to use self.check_servo_states().