### PR TITLE
Any elf file is available by write_firmware.py

### DIFF
--- a/rcb4/apps/write_firmware.py
+++ b/rcb4/apps/write_firmware.py
@@ -46,7 +46,11 @@ def main():
     print(f"ST-Link path found: {st_flash_path}")
 
     print("Retrieving latest ELF file...")
-    elf_path = kondoh7_elf('latest')
+    args = sys.argv
+    if len(args) == 2:
+        elf_path = args[1]
+    else:
+        elf_path = kondoh7_elf('latest')
     if not elf_path or not Path(elf_path).is_file():
         print("Error: ELF file not found. Please check the path or filename.")
         sys.exit(5)

--- a/rcb4/apps/write_firmware.py
+++ b/rcb4/apps/write_firmware.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 
+import argparse
 from pathlib import Path
 import shutil
 import subprocess
@@ -34,6 +35,15 @@ def flash_bin_to_device(st_flash_path, bin_path):
 
 
 def main():
+    parser = argparse.ArgumentParser(description="Flash firmware to a device.")
+    parser.add_argument(
+        "--firmware",
+        type=str,
+        help="Path to the firmware ELF file. If not provided, the latest kondoh7 ELF file will be used.",
+        default=None
+    )
+    args = parser.parse_args()
+
     print("Checking dependencies...")
     check_dependencies()
     print("Dependencies are satisfied.")
@@ -45,12 +55,8 @@ def main():
         sys.exit(4)
     print(f"ST-Link path found: {st_flash_path}")
 
-    print("Retrieving latest ELF file...")
-    args = sys.argv
-    if len(args) == 2:
-        elf_path = args[1]
-    else:
-        elf_path = kondoh7_elf('latest')
+    print("Retrieving ELF file...")
+    elf_path = args.firmware if args.firmware else kondoh7_elf('latest')
     if not elf_path or not Path(elf_path).is_file():
         print(f"Error: ELF file not found: {elf_path}")
         print("Please check the path or filename.")

--- a/rcb4/apps/write_firmware.py
+++ b/rcb4/apps/write_firmware.py
@@ -52,7 +52,8 @@ def main():
     else:
         elf_path = kondoh7_elf('latest')
     if not elf_path or not Path(elf_path).is_file():
-        print("Error: ELF file not found. Please check the path or filename.")
+        print(f"Error: ELF file not found: {elf_path}")
+        print("Please check the path or filename.")
         sys.exit(5)
     print(f"ELF file found: {elf_path}")
 


### PR DESCRIPTION
If command line argument is given, use the argument as elf file path.

```
$ rcb4-write-firmware ~/Downloads/air_relay_rev2.elf 
Checking dependencies...
Dependencies are satisfied.
Locating ST-Link path...
ST-Link path found: /home/naoya/.rcb4/stlink/stlink-1.7.0/build/Release/bin/st-flash
Retrieving latest ELF file...
ELF file found: /home/naoya/Downloads/air_relay_rev2.elf
Converting ELF to BIN: /home/naoya/Downloads/air_relay_rev2.bin
ELF successfully converted to BIN.
Flashing BIN to device...
BIN successfully flashed to device.
```

I need this feature for air relay firmware.