### PR TITLE
Update PressureControl msg: change field name and add release_duration

### DIFF
--- a/ros/kxr_controller/action/PressureControl.action
+++ b/ros/kxr_controller/action/PressureControl.action
@@ -1,6 +1,14 @@
-uint16 board_idx  # Do not use board id? (Currently, bus-connected air board is not supported)
-float32 start_pressure  # Threshold [kPa] to start pump (Currently, pressurization is not supported)
-float32 stop_pressure  # Threshold [kPa] to stop pump (Currently, pressurization is not supported)
-bool release  # Set true to release air by opening valve.
+uint16 board_idx # ICS controller ID (2n or 2n+1)
+
+# Pressure control parameters
+# If trigger_pressure < target_pressure: pressurization mode
+# If trigger_pressure > target_pressure: depressurization mode
+float32 trigger_pressure # Pressure threshold to start valve operation [kPa]
+float32 target_pressure # Desired pressure level for optimal operation [kPa]
+
+# Air release parameters
+# If the value is zero, pressure control is performed based on trigger_pressure and target_pressure
+# If the value is greater than zero, solenoid valves opens for release_duration[s] and the work conducts to the atmosphere
+float32 release_duration # Duration for atmospheric venting [s]
 ---
 ---

--- a/ros/kxr_controller/msg/PressureControl.msg
+++ b/ros/kxr_controller/msg/PressureControl.msg
@@ -1,4 +1,12 @@
-uint16 board_idx  # Do not use board id? (Currently, bus-connected air board is not supported)
-float32 start_pressure  # Threshold [kPa] to start pump (Currently, pressurization is not supported)
-float32 stop_pressure  # Threshold [kPa] to stop pump (Currently, pressurization is not supported)
-bool release  # Set true to release air by opening valve.
+uint16 board_idx # ICS controller ID (2n or 2n+1)
+
+# Pressure control parameters
+# If trigger_pressure < target_pressure: pressurization mode
+# If trigger_pressure > target_pressure: depressurization mode
+float32 trigger_pressure # Pressure threshold to start valve operation [kPa]
+float32 target_pressure # Desired pressure level for optimal operation [kPa]
+
+# Air release parameters
+# If the value is zero, pressure control is performed based on trigger_pressure and target_pressure
+# If the value is greater than zero, solenoid valves opens for release_duration[s] and the work conducts to the atmosphere
+float32 release_duration # Duration for atmospheric venting [s]

--- a/ros/kxr_controller/node_scripts/rcb4_ros_bridge.py
+++ b/ros/kxr_controller/node_scripts/rcb4_ros_bridge.py
@@ -830,7 +830,8 @@ class RCB4ROSBridge:
         while self.pressure_control_running[idx]:
             pressure = self.average_pressure(idx)
             if pressure is None:
-                rospy.sleep()
+                rospy.sleep(0.1)
+                continue
             if air_work_on is False and pressure > trigger_pressure:
                 self.air_disconnect_lock.acquire(idx)
                 self.pump_on_lock.acquire(idx)

--- a/ros/kxr_controller/python/kxr_controller/kxr_interface.py
+++ b/ros/kxr_controller/python/kxr_controller/kxr_interface.py
@@ -177,12 +177,12 @@ class KXRROSRobotInterface(ROSRobotInterfaceBase):
             return
         return rospy.wait_for_message(self.stretch_topic_name, Stretch)
 
-    def send_pressure_control(self, board_idx, start_pressure, stop_pressure, release):
+    def send_pressure_control(self, board_idx, trigger_pressure, target_pressure, release_duration):
         goal = PressureControlGoal(
             board_idx=board_idx,
-            start_pressure=start_pressure,
-            stop_pressure=stop_pressure,
-            release=release,
+            trigger_pressure=trigger_pressure,
+            target_pressure=target_pressure,
+            release_duration=release_duration,
         )
         client = self.pressure_control_client
         if client.get_state() == actionlib_msgs.msg.GoalStatus.ACTIVE:


### PR DESCRIPTION
### Overview

- Change `PressureControl` message field for easy understanding.
  - start_pressure -> trigger_pressure
  - stop_pressure -> target_pressure

- Add release_duration field. The duration to open air_connect_valve.

### Note

This PR depends on https://github.com/iory/rcb4/pull/141, https://github.com/iory/riberry/pull/107