### PR TITLE
Avoid TypeError in default_controller()

### DIFF
--- a/ros/kxr_controller/python/kxr_controller/kxr_interface.py
+++ b/ros/kxr_controller/python/kxr_controller/kxr_interface.py
@@ -210,8 +210,9 @@ class KXRROSRobotInterface(ROSRobotInterfaceBase):
         }
 
     def default_controller(self):
+        namespace = self.namespace or ""
         controller_names = rospy.get_param(
-            self.namespace + 'default_controller', None)
+            namespace + 'default_controller', None)
         if controller_names is None:
             return [self.fullbody_controller]
         controllers = []
@@ -222,6 +223,6 @@ class KXRROSRobotInterface(ROSRobotInterfaceBase):
                 "controller_state": cont_name + "/state",
                 "action_type": control_msgs.msg.FollowJointTrajectoryAction,
                 "joint_names": rospy.get_param(
-                    self.namespace + cont_name + '/joints'),
+                    namespace + cont_name + '/joints'),
             })
         return controllers


### PR DESCRIPTION
When creating an instance of KXRROSRobotInterface without explicitly providing a namespace, the parent class constructor overwrites [self.namespace with None](https://github.com/iory/scikit-robot/blob/46b0066c3ef141873058846aad8134de51447e3e/skrobot/interfaces/ros/base.py#L107). This causes the following error:
```
Traceback (most recent call last):
  File "/home/rock/ros/kxr/src/hand_v3/node_scripts/hand_interface.py", line 60, in __init__
    self.ri = KXRROSRobotInterface(  # NOQA
  File "/home/rock/ros/kxr/src/rcb4/ros/kxr_controller/python/kxr_controller/kxr_interface.py", line 35, in __init__
    super(KXRROSRobotInterface, self).__init__(*args, **kwargs)
  File "/home/rock/ros/kxr/src/scikit-robot/skrobot/interfaces/ros/base.py", line 123, in __init__
    self.controller_actions = self.add_controller(
  File "/home/rock/ros/kxr/src/scikit-robot/skrobot/interfaces/ros/base.py", line 274, in add_controller
    for controller in self.default_controller():
  File "/home/rock/ros/kxr/src/rcb4/ros/kxr_controller/python/kxr_controller/kxr_interface.py", line 215, in default_controller
    self.namespace + 'default_controller', None)
TypeError: unsupported operand type(s) for +: 'NoneType' and 'str'
```
To fix this, this PR converts namespace to an empty string if it is None. 