### PR TITLE
[Github Actions] Add test to fix typos

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,6 +28,17 @@ jobs:
     - name: Run Ruff
       run: ruff check .
 
+  typos:
+    name: Typos
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - name: typos-action
+        uses: crate-ci/typos@v1.29.10
+
   tests:
     name: Run Unit Tests
     runs-on: ${{ matrix.os }}
@@ -99,7 +110,7 @@ jobs:
 
   industrial_ci:
     name: Run ROS Tests
-    needs: [formatting, tests]
+    needs: [formatting, tests, typos]
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,3 +43,12 @@ order-by-type = false
 [tool.ruff.lint.flake8-tidy-imports.banned-api]
     "IPython.embed".msg = "you forgot to remove a debug embed ;)"
     "numpy.empty".msg = "uninitialized arrays are haunted try numpy.zeros"
+
+[tool.typos]
+default.extend-ignore-re = [
+    "(?Rm)^.*(#|//)\\s*spellchecker:disable-line$",  # spellchecker:disable-line
+    "(?s)(#|//)\\s*spellchecker:off.*?\\n\\s*(#|//)\\s*spellchecker:on"  # spellchecker:<on|off>
+]
+default.extend-ignore-identifiers-re = [
+    # Add individual words here to ignore them
+]

--- a/rcb4/armh7interface.py
+++ b/rcb4/armh7interface.py
@@ -115,12 +115,12 @@ servo_eeprom_params64 = {
 }
 
 
-def padding_bytearray(ba, n):
-    padding_length = n - len(ba)
+def padding_bytearray(byte_array, n):
+    padding_length = n - len(byte_array)
     if padding_length > 0:
-        return bytearray(padding_length) + ba
+        return bytearray(padding_length) + byte_array
     else:
-        return ba
+        return byte_array
 
 
 class ARMH7Interface:

--- a/ros/kxr_controller/CMakeLists.txt
+++ b/ros/kxr_controller/CMakeLists.txt
@@ -75,7 +75,7 @@ add_message_files(
 
 # generate the dynamic_reconfigure config file
 generate_dynamic_reconfigure_options(
-  cfg/KXRParameteres.cfg
+  cfg/KXRParameters.cfg
 )
 
 generate_messages(

--- a/ros/kxr_controller/cfg/KXRParameters.cfg
+++ b/ros/kxr_controller/cfg/KXRParameters.cfg
@@ -14,4 +14,4 @@ gen.add("wheel_frame_count", int_t, 0, "Frame Count for Wheel", 1, 1, 255)
 gen.add("temperature_limit", double_t, 0, "Temperature limit in celsius", 80, 0, 120)
 gen.add("current_limit", double_t, 0, "Current limit in Amp", 4.0, 0.0, 6.0)
 
-exit(gen.generate(PACKAGE, PACKAGE, "KXRParameteres"))
+exit(gen.generate(PACKAGE, PACKAGE, "KXRParameters"))

--- a/ros/kxr_controller/node_scripts/rcb4_ros_bridge.py
+++ b/ros/kxr_controller/node_scripts/rcb4_ros_bridge.py
@@ -16,7 +16,7 @@ from control_msgs.msg import FollowJointTrajectoryAction
 from control_msgs.msg import FollowJointTrajectoryGoal
 from dynamic_reconfigure.server import Server
 import geometry_msgs.msg
-from kxr_controller.cfg import KXRParameteresConfig as Config
+from kxr_controller.cfg import KXRParametersConfig as Config
 from kxr_controller.msg import AdjustAngleVectorAction
 from kxr_controller.msg import AdjustAngleVectorResult
 from kxr_controller.msg import PressureControl
@@ -132,7 +132,7 @@ def set_fullbody_controller(joint_names):
     rospy.set_param("fullbody_controller", controller_yaml_dict)
 
 
-def set_joint_state_controler():
+def set_joint_state_controller():
     rospy.set_param(
         "joint_state_controller",
         {"type": "joint_state_controller/JointStateController", "publish_rate": 10},
@@ -210,7 +210,7 @@ class RCB4ROSBridge:
 
     def setup_ros_parameters(self):
         """Configure joint state and full body controllers."""
-        set_joint_state_controler()
+        set_joint_state_controller()
         self.set_fullbody_controller()
 
     def setup_publishers_and_servers(self):

--- a/ros/kxreus/requirements.in
+++ b/ros/kxreus/requirements.in
@@ -1,3 +1,3 @@
 scikit-robot>=0.0.45
-urdfeus>=0.0.12  # support mass paramerter for euslisp model
+urdfeus>=0.0.12  # support mass parameter for euslisp model
 pycollada==0.7.1


### PR DESCRIPTION
Fixing typos in robot software development improves code readability, reduces bugs, enhances maintainability, prevents misinterpretations in logs and documentation, and ensures smooth CI/CD processes. Typos can lead to incorrect variable references, misunderstandings, and potential safety risks in robotic operations. 

# Summary of Changes:
- Added a new typos job in .github/workflows/test.yml to automatically check for typos using typos-action.

Typo tests are not perfect, but they improve code maintainability and prevent developers from being distracted by minor mistakes.
