### PR TITLE
Fix air_work_on initialization to match actual state

### DIFF
--- a/ros/kxr_controller/node_scripts/rcb4_ros_bridge.py
+++ b/ros/kxr_controller/node_scripts/rcb4_ros_bridge.py
@@ -841,7 +841,8 @@ class RCB4ROSBridge:
             self.release_air_work(idx, release_duration)
             self.pressure_control_running[idx] = False
             return
-        air_work_on = False
+        air_work_on = idx in self.air_disconnect_lock.active_lock_idx()\
+            and idx in self.pump_on_lock.active_lock_idx()
         while self.pressure_control_running[idx]:
             pressure = self.average_pressure(idx)
             if pressure is None:

--- a/ros/kxr_controller/node_scripts/rcb4_ros_bridge.py
+++ b/ros/kxr_controller/node_scripts/rcb4_ros_bridge.py
@@ -841,8 +841,7 @@ class RCB4ROSBridge:
             self.release_air_work(idx, release_duration)
             self.pressure_control_running[idx] = False
             return
-        air_work_on = idx in self.air_disconnect_lock.active_lock_idx()\
-            and idx in self.pump_on_lock.active_lock_idx()
+        air_work_on = self.air_work_status(idx)
         while self.pressure_control_running[idx]:
             pressure = self.average_pressure(idx)
             if pressure is None:
@@ -991,6 +990,15 @@ class RCB4ROSBridge:
         if ret is None:
             return False
         return True
+
+    def air_work_status(self, idx):
+        """Returns whether or not the pump is working on air work.
+
+        air_disconnect_lock and pump_on_lock are applied when start_air_work()
+        and are removed when stop_air_work().
+        """
+        return idx in self.air_disconnect_lock.active_lock_idx()\
+            and idx in self.pump_on_lock.active_lock_idx()
 
     def pressure_control_callback(self, goal):
         if not self.interface.is_opened():

--- a/ros/kxr_controller/python/kxr_controller/multi_lock.py
+++ b/ros/kxr_controller/python/kxr_controller/multi_lock.py
@@ -68,5 +68,5 @@ class MultiLock:
         # print(f"[{self.lock_name}] All locks are released. Proceeding.")
 
     def active_lock_idx(self):
-        return  [key for key, value in {40: True, 39: True}.items()
+        return  [key for key, value in self.lock_status.items()
                  if value is True]


### PR DESCRIPTION
If PressureControl action is resent while the pump is running with the same ID, it causes `air_work_on` to be  reinitialized to `False` even though it is actually `True`, and the pump cannot stop.

I fixed initialization with `air_work_on=True` when lock is applied, since lock is always released when `air_work_on` is `False`.