### PR TITLE
Update numpy version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ colorama
 cstruct
 gdown
 libusb1
-numpy
+numpy>=1.22.0
 pandas
 pyelftools
 pyserial


### PR DESCRIPTION
Using numpy versions earlier than 1.22.0 can cause the following errors, which may be difficult for beginners to debug:
```
ModuleNotFoundError: No module named 'numpy.typing'
AttributeError: module 'numpy' has no attribute 'typeDict'
```

