### PR TITLE
Set default control loop rate to 30

### DIFF
--- a/ros/kxr_controller/launch/kxr_controller.launch
+++ b/ros/kxr_controller/launch/kxr_controller.launch
@@ -8,7 +8,7 @@
   <arg name="publish_battery_voltage" default="false" />
   <arg name="control_pressure" default="false" />
   <arg name="imu_frame_id" default="/bodyset94472077639384" />
-  <arg name="control_loop_rate" default="20" />
+  <arg name="control_loop_rate" default="30" />
   <arg name="use_rcb4" default="false" doc="Flag to use RCB4 mini board"/>
   <arg name="device" default="" doc="Device path"/>
   <arg name="model_server_port" default="8123" />

--- a/ros/kxr_controller/node_scripts/rcb4_ros_bridge.py
+++ b/ros/kxr_controller/node_scripts/rcb4_ros_bridge.py
@@ -1185,7 +1185,7 @@ class RCB4ROSBridge:
         self.last_check_time = rospy.Time.now()
 
     def run(self):
-        rate = rospy.Rate(rospy.get_param(self.base_namespace + "/control_loop_rate", 20))
+        rate = rospy.Rate(rospy.get_param(self.base_namespace + "/control_loop_rate", 30))
 
         self.publish_attempts = {}
         self.publish_successes = {}

--- a/ros/kxr_controller/node_scripts/rcb4_ros_bridge.py
+++ b/ros/kxr_controller/node_scripts/rcb4_ros_bridge.py
@@ -1197,6 +1197,7 @@ class RCB4ROSBridge:
             "~check_board_communication_interval", 2
         )
         self.success_rate_threshold = 0.8  # Minimum success rate required
+        use_rcb4 = rospy.get_param("~use_rcb4")
 
         while not rospy.is_shutdown():
             if self._update_current_limit:
@@ -1225,7 +1226,7 @@ class RCB4ROSBridge:
             self.publish_imu_message()
             self.publish_sensor_values()
             self.publish_battery_voltage_value()
-            if rospy.get_param("~use_rcb4") is False and self.control_pressure:
+            if use_rcb4 is False and self.control_pressure:
                 self.publish_pressure_control()
                 success = self.publish_pressure()
                 self.publish_attempts["pressure"] += 1

--- a/ros/kxr_controller/src/kxr_robot_hardware.cpp
+++ b/ros/kxr_controller/src/kxr_robot_hardware.cpp
@@ -40,7 +40,7 @@ bool KXRRobotHW::init(ros::NodeHandle& root_nh, ros::NodeHandle& robot_hw_nh) {
     double control_loop_rate;
     if (!robot_hw_nh.getParam(clean_namespace + "/control_loop_rate", control_loop_rate) ||
         control_loop_rate <= 0.0) {
-        control_loop_rate = 20.0;
+        control_loop_rate = 30.0;
     }
     control_loop_period_ = ros::Duration(1.0 / control_loop_rate);
 


### PR DESCRIPTION
This PR increases loop rate by not using `rospy.get_param()` each time in the run() loop.
- If `control_loop_rate` is 30, /current_joint_states rate is about 30.
- If `control_loop_rate` is 100, /current_joint_states rate is about 40.

Launch
```
<include file="$(find kxr_controller)/launch/kxr_controller.launch">
  <arg name="urdf_path" value="$(find yamaguchi_7axis_arm_no_worm_with_vacuum_base_ver10)/urdf/yamaguchi_7axis_arm_no_worm_with_vacuum_base_ver10.urdf" />
  <arg name="servo_config_path" value="$(find yamaguchi_7axis_arm_no_worm_with_vacuum_base_ver10)/config/servo_config.yaml" />
  <arg name="publish_sensor" value="false" />
  <arg name="publish_imu" value="false" />
  <arg name="publish_battery_voltage" value="false" />
  <arg name="control_pressure" value="true" />
  <arg name="control_loop_rate" value="30" />
  <arg name="read_current" default="false" />
  <arg name="read_temperature" default="false" />
</include>
```

Result
```
$ rostopic hz /current_joint_states -w20
average rate: 30.429
        min: 0.024s max: 0.042s std dev: 0.00478s window: 20
average rate: 30.025
        min: 0.021s max: 0.040s std dev: 0.00445s window: 20
average rate: 29.548
        min: 0.021s max: 0.047s std dev: 0.00690s window: 20
```
