### PR TITLE
Add update_kxr_parameters to change dynamic reconfigure params and command joint state mux

### DIFF
--- a/ros/kxr_controller/launch/kxr_controller.launch
+++ b/ros/kxr_controller/launch/kxr_controller.launch
@@ -62,6 +62,13 @@
     <node name="urdf_model_server"
           pkg="kxr_models" type="urdf_model_server.py" >
     </node>
+
+    <node name="command_joint_state_mux"
+          pkg="topic_tools" type="mux"
+          output="screen"
+          args="command_joint_state command_joint_state_from_robot_hardware command_joint_state_from_joint_state" >
+      <param name="initial_topic" value="command_joint_state_from_robot_hardware" />
+    </node>
   </group>
 
   <group unless="$(eval len(arg('namespace')) > 0)">
@@ -103,6 +110,13 @@
 
     <node name="urdf_model_server"
           pkg="kxr_models" type="urdf_model_server.py" >
+    </node>
+
+    <node name="command_joint_state_mux"
+          pkg="topic_tools" type="mux"
+          output="screen"
+          args="command_joint_state command_joint_state_from_robot_hardware command_joint_state_from_joint_state" >
+      <param name="initial_topic" value="command_joint_state_from_robot_hardware" />
     </node>
   </group>
 

--- a/ros/kxr_controller/package.xml
+++ b/ros/kxr_controller/package.xml
@@ -36,6 +36,7 @@
   <exec_depend>cmake_modules</exec_depend>
   <exec_depend>kxr_models</exec_depend>
   <exec_depend>rviz</exec_depend>
+  <exec_depend>topic_tools</exec_depend>
 
   <test_depend>roslaunch</test_depend>
   <test_depend>rostest</test_depend>

--- a/ros/kxr_controller/python/kxr_controller/kxr_interface.py
+++ b/ros/kxr_controller/python/kxr_controller/kxr_interface.py
@@ -17,6 +17,7 @@ from kxr_controller.msg import ServoOnOffGoal
 from kxr_controller.msg import Stretch
 from kxr_controller.msg import StretchAction
 from kxr_controller.msg import StretchGoal
+from kxr_controller.reconfigure_utils import update_kxr_parameters
 
 
 class KXRROSRobotInterface(ROSRobotInterfaceBase):
@@ -197,6 +198,14 @@ class KXRROSRobotInterface(ROSRobotInterfaceBase):
         return rospy.wait_for_message(
             self.pressure_topic_name_base + f"{board_idx}", std_msgs.msg.Float32
         )
+
+    def update_kxr_parameters(self, frame_count=None, wheel_frame_count=None,
+                              temperature_limit=None, current_limit=None, **kwargs):
+        return update_kxr_parameters(
+            namespace=self.namespace,
+            server_name='rcb4_ros_bridge', frame_count=frame_count,
+            wheel_frame_count=current_limit, temperature_limit=temperature_limit,
+            current_limit=current_limit)
 
     def select_command_joint_state(self, source_topic):
         from topic_tools.srv import MuxSelect

--- a/ros/kxr_controller/python/kxr_controller/kxr_interface.py
+++ b/ros/kxr_controller/python/kxr_controller/kxr_interface.py
@@ -198,6 +198,72 @@ class KXRROSRobotInterface(ROSRobotInterfaceBase):
             self.pressure_topic_name_base + f"{board_idx}", std_msgs.msg.Float32
         )
 
+    def select_command_joint_state(self, source_topic):
+        from topic_tools.srv import MuxSelect
+
+        if source_topic not in [
+            'command_joint_state_from_robot_hardware',
+                                    'command_joint_state_from_joint_state',
+                                ]:
+            raise ValueError(
+                f"Invalid source_topic '{source_topic}'. "
+                + "Valid options are: ['command_joint_state_from_robot_hardware', "
+                + 'command_joint_state_from_joint_state]')
+        service_name = f'/{self.namespace}/command_joint_state_select'
+        rospy.wait_for_service(service_name)
+        try:
+            select_srv = rospy.ServiceProxy(service_name, MuxSelect)
+            resp = select_srv(source_topic)
+            rospy.loginfo(f"[{self.namespace}] switched to '{source_topic}', "
+                          + f"prev='{resp.prev_topic}'")
+            return resp.prev_topic
+        except rospy.ServiceException as e:
+            rospy.logerr(f"Failed to call {service_name}: {e}")
+            return None
+
+    def switch_fullbody_controller(self, start=True):
+        """ Start or stop the `fullbody_controller` in the given namespace.
+
+        Args:
+            start: True to start the controller, False to stop it.
+
+        Returns:
+            True if the switch succeeded; False otherwise.
+        """
+        from controller_manager_msgs.srv import SwitchController
+        from controller_manager_msgs.srv import SwitchControllerRequest
+
+        service_name = f"/{self.namespace}/controller_manager/switch_controller"
+        rospy.wait_for_service(service_name)
+
+        req = SwitchControllerRequest()
+        if start:
+            req.start_controllers = ["fullbody_controller"]
+            req.stop_controllers = []
+            action = "start"
+        else:
+            req.start_controllers = []
+            req.stop_controllers = ["fullbody_controller"]
+            action = "stop"
+
+        req.strictness = SwitchControllerRequest.BEST_EFFORT
+        req.start_asap   = False
+        req.timeout      = 0.0
+
+        try:
+            switch = rospy.ServiceProxy(service_name, SwitchController)
+            resp   = switch(req)
+        except rospy.ServiceException as e:
+            rospy.logerr(f"Service call failed: {e}")
+            return False
+
+        if resp.ok:
+            rospy.loginfo(f"{action.capitalize()} fullbody_controller")
+            return True
+        else:
+            rospy.logerr(f"Failed to {action} fullbody_controller")
+            return False
+
     @property
     def fullbody_controller(self):
         cont_name = "fullbody_controller"

--- a/ros/kxr_controller/python/kxr_controller/reconfigure_utils.py
+++ b/ros/kxr_controller/python/kxr_controller/reconfigure_utils.py
@@ -1,0 +1,28 @@
+import rospy
+
+from kxr_controller.module_loader import ModuleLoader
+
+_client_loader = ModuleLoader('dynamic_reconfigure.client', 'Client')
+
+def update_kxr_parameters(server_name='rcb4_ros_bridge', frame_count=None,
+                          wheel_frame_count=None, temperature_limit=None,
+                          current_limit=None,
+                          namespace=None,
+                          **kwargs):
+    if namespace is not None:
+        server_name = namespace + '/' + server_name
+    Client = _client_loader.get_module()
+    client = Client(server_name, timeout=5.0)
+    cfg = {}
+    if frame_count is not None:
+        cfg['frame_count'] = frame_count
+    if wheel_frame_count is not None:
+        cfg['wheel_frame_count'] = wheel_frame_count
+    if temperature_limit is not None:
+        cfg['temperature_limit']  = temperature_limit
+    if current_limit is not None:
+        cfg['current_limit'] = current_limit
+
+    updated = client.update_configuration(cfg)
+    rospy.loginfo(f"[update_kxr_parameters] Change reconfigure parameters: {updated}")
+    return updated

--- a/ros/kxr_controller/src/kxr_robot_hardware.cpp
+++ b/ros/kxr_controller/src/kxr_robot_hardware.cpp
@@ -90,10 +90,10 @@ bool KXRRobotHW::init(ros::NodeHandle& root_nh, ros::NodeHandle& robot_hw_nh) {
 
     joint_state_sub_ = nh_.subscribe<sensor_msgs::JointState>(
             clean_namespace + "/current_joint_states", 1, &KXRRobotHW::jointStateCallback, this);
-    joint_command_pub_ =
-            nh_.advertise<sensor_msgs::JointState>(clean_namespace + "/command_joint_state", 1);
+    joint_command_pub_ = nh_.advertise<sensor_msgs::JointState>(
+            clean_namespace + "/command_joint_state_from_robot_hardware", 1);
     joint_velocity_command_pub_ = nh_.advertise<sensor_msgs::JointState>(
-            clean_namespace + "/velocity_command_joint_state", 1);
+            clean_namespace + "/velocity_command_joint_state_from_robot_hardware", 1);
     return true;
 }
 


### PR DESCRIPTION
Added a mux to support leader-follower control by relaying one robot's joint states directly as command inputs to the other, allowing separation from ROS Control outputs.