### PR TITLE
[WIP] Calibrate KJS force sensor

### DIFF
--- a/rcb4/units.py
+++ b/rcb4/units.py
@@ -31,3 +31,43 @@ def convert_data(raw_data, range_g):
     max_value = 32767
     conversion_factor = (range_g * 2) / (max_value * 2)
     return np.array(raw_data) * conversion_factor
+
+
+def convert_adc_to_newton(adc_value, resistor_k=15.0):
+    """
+    Convert ADC value to Force [N] using HSFPAR003A parameters.
+
+    Parameters
+    ----------
+    adc_value : float
+        The raw ADC value (or sum of ADC values).
+    resistor_k : float, optional
+        The resistance value of the gain resistor Rg in kOhm.
+        Default is 15.0 kOhm.
+
+    Returns
+    -------
+    force_n : float
+        Calculated force in Newtons.
+
+    Notes
+    -----
+    Calculation Logic:
+        1. Gain (G) = 1 + 100k / Rg
+        2. Sensitivity (S) = 3.7 mV/V/N = 0.0037 V/V/N
+        3. Vdd = 3.3 V
+        4. Resolution = 12 bit (4096)
+
+        Force per LSB (K) is derived from:
+        K = (Vdd / Resolution) / (Gain * S * Vdd)
+
+        Force [N] = adc_value * K
+    """
+    # Constants from datasheet and circuit
+    vdd = 3.3
+    sensitivity = 0.0037  # V/V/N
+    adc_resolution = 4096.0
+    gain = 1.0 + (100.0 / resistor_k)
+    force_factor = (vdd / adc_resolution) / (gain * sensitivity * vdd)
+    force_n = adc_value * force_factor
+    return force_n


### PR DESCRIPTION
# Description

This PR implements calibration, unit conversion (ADC to Newton), and drift detection for the KJS force sensors (Alps Alpine HSFPAR003A).

Previously, the bridge only published raw ADC values for individual sensor elements. This update aggregates the 4-element sensor values, applies a conversion formula based on the hardware specification, and provides a mechanism to zero-out the preload via a ROS service.

# Key Changes

1. Unit Conversion (ADC to Newton)
 - Implemented convert_adc_to_newton method.
 - Parameters:
   - Sensor: Alps Alpine HSFPAR003A
   - Gain Resistor ($R_G$): 15 kΩ (resulting in Gain $\approx$ 7.67)
   - Sensitivity: 3.7 mV/V/N
   - ADC: 12-bit resolution at 3.3V Vdd

2. Calibration Service
- Service Name: ~calibrate_force_sensor (std_srvs/Trigger)
- Logic:
  - Uses the internal history buffer (recent_adc_history) to calculate the average offset for each of the 4 sensor elements.
  - Optimization: Uses cached history instead of blocking serial_call_with_retry for faster response.
  - Safety: Checks if the sensor values are too low (threshold < 10.0) to ensure proper preload is applied before calibrating.

3. Drift Detection (Warmup Check)
- Implemented a background timer (drift_check_callback) running at 1-minute intervals.
- Checks if the average force has drifted by more than 0.1 N compared to the previous minute.
- Publishes the status to .../force_drifted to indicate if the sensor is still warming up.

4. Updated Topics
For each sensor ID (e.g., `/kjs/19/...`), the following topics are now available:

| Topic Suffix | Message Type | Description |
| :--- | :--- | :--- |
| `/force` | `WrenchStamped` | **Raw** sum of ADC values (always published). |
| `/force_corrected` | `WrenchStamped` | Net ADC sum (Raw - Offset). Only published after calibration. |
| `/force_N` | `WrenchStamped` | Force converted to **Newtons**. Only published after calibration. |
| `/force_drifted` | `Bool` (Latched) | `True` if drift > 0.1N/min (unstable), `False` otherwise. |

# Notes
Sensor Warm-up: The force sensor values (HSFPAR003A) tend to drift immediately after power-on due to initial temperature changes. It typically takes about 10 minutes for the values to stabilize. Please wait for the force_drifted topic to become False before performing critical calibration.

# How to Test

1. Launch the bridge node.
2. Monitor `/kjs/{id}/force` to see raw values.
3. Call the service: `rosservice call /rcb4_ros_bridge/calibrate_force_sensor`.
4. Verify that `/kjs/{id}/force_N` is now being published and is near 0.0 N.
5. Monitor `/kjs/{id}/force_drifted` to check the stability of the sensor.